### PR TITLE
Add Node interface and node query with globalIds

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -13,10 +13,18 @@ scalar JSONObject
 
 directive @authenticate(roles: [String] = ["REGULAR"]) on FIELD_DEFINITION
 
+# An object with a Globally Unique ID
+interface Node {
+  # The ID of the object.
+  id: ID!
+}
+
 """
 App queries
 """
 type Query {
+  node(id: ID!): Node
+
   """
   Retrieve all decks for the logged user
   """

--- a/api/graphql/types/User.graphql
+++ b/api/graphql/types/User.graphql
@@ -1,7 +1,7 @@
 """
 User entity
 """
-type User {
+type User implements Node {
   """
   User id
   """

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,17 +1,16 @@
 import express from 'express'
 import helmet from 'helmet'
-import mongoose from 'mongoose'
 import morgan from 'morgan'
 
 import graphqlMiddleware from './middlewares/apollo'
 import authMiddleware from './middlewares/auth'
 import ioMiddleware from './middlewares/io'
+import { getConnection } from './mongo/connection'
 import authRouter from './routes/auth'
 
 const app = express()
 
 const PORT = process.env.PORT ?? 5000
-const MONGO_URI = process.env.MONGO_URI ?? 'mongodb://localhost:27017/cramkle'
 
 app.use(helmet())
 app.use(morgan('dev'))
@@ -22,21 +21,13 @@ graphqlMiddleware.set(app)
 
 app.use('/auth', authRouter)
 
-mongoose
-  .connect(MONGO_URI, {
-    useNewUrlParser: true,
-    useCreateIndex: true,
-    useUnifiedTopology: true,
-    useFindAndModify: false,
-  })
+getConnection()
   .then(() => {
     app.listen(PORT, () => {
       // eslint-disable-next-line no-console
       console.log(`App listening on https://localhost:${PORT}`)
     })
   })
-  .catch((e) => {
-    console.error('Failed to obtain a connection to MongoDB')
-    console.error(e)
+  .catch(() => {
     process.exit(1)
   })

--- a/api/src/mongo/connection.ts
+++ b/api/src/mongo/connection.ts
@@ -1,0 +1,26 @@
+import mongoose, { Mongoose } from 'mongoose'
+
+const MONGO_URI = process.env.MONGO_URI ?? 'mongodb://localhost:27017/cramkle'
+
+let connection: Mongoose | null = null
+
+export const getConnection = async () => {
+  if (connection !== null) {
+    return connection
+  }
+
+  try {
+    // eslint-disable-next-line require-atomic-updates
+    connection = await mongoose.connect(MONGO_URI, {
+      useNewUrlParser: true,
+      useCreateIndex: true,
+      useUnifiedTopology: true,
+      useFindAndModify: false,
+    })
+    return connection
+  } catch (err) {
+    console.error('Failed to obtain a connection to MongoDB')
+    console.error(err)
+    throw err
+  }
+}

--- a/api/src/resolvers/index.ts
+++ b/api/src/resolvers/index.ts
@@ -18,6 +18,7 @@ import {
   queries as modelQueries,
   root as modelRoot,
 } from './model'
+import { resolvers as nodeResolvers, root as nodeRoot } from './node'
 import {
   mutations as noteMutations,
   queries as noteQueries,
@@ -44,12 +45,14 @@ export default {
   ...fieldValueRoot,
   ...flashCardRoot,
   ...modelRoot,
+  ...nodeRoot,
   ...noteRoot,
   ...templateRoot,
   ...userRoot,
   Query: {
     ...deckQueries,
     ...modelQueries,
+    ...nodeResolvers,
     ...noteQueries,
     ...studyQueries,
     ...templateQueries,

--- a/api/src/resolvers/node.ts
+++ b/api/src/resolvers/node.ts
@@ -1,0 +1,31 @@
+import { IResolverObject, IResolvers } from 'graphql-tools'
+
+import { getConnection } from '../mongo/connection'
+import { decodeModelId } from '../utils/graphqlID'
+
+export const root: IResolvers = {
+  Node: {
+    __resolveType: (root: { id: string }) => {
+      const [typeName] = decodeModelId(root.id)
+
+      return typeName
+    },
+  },
+}
+
+export const resolvers: IResolverObject = {
+  node: async (_: unknown, { id }: { id: string }) => {
+    const [typeName, objectId] = decodeModelId(id)
+
+    const mongoose = await getConnection()
+
+    const documentModel = mongoose.model(typeName)
+    const document = await documentModel.findById(objectId)
+
+    if (!document) {
+      return null
+    }
+
+    return { id, ...document?.toObject?.() }
+  },
+}

--- a/api/src/resolvers/node.ts
+++ b/api/src/resolvers/node.ts
@@ -6,7 +6,7 @@ import { decodeModelId } from '../utils/graphqlID'
 export const root: IResolvers = {
   Node: {
     __resolveType: (root: { id: string }) => {
-      const [typeName] = decodeModelId(root.id)
+      const { typeName } = decodeModelId(root.id)
 
       return typeName
     },
@@ -15,7 +15,7 @@ export const root: IResolvers = {
 
 export const resolvers: IResolverObject = {
   node: async (_: unknown, { id }: { id: string }) => {
-    const [typeName, objectId] = decodeModelId(id)
+    const { typeName, objectId } = decodeModelId(id)
 
     const mongoose = await getConnection()
 

--- a/api/src/resolvers/user.ts
+++ b/api/src/resolvers/user.ts
@@ -2,12 +2,11 @@ import { AuthenticationError } from 'apollo-server'
 import { IResolverObject, IResolvers } from 'graphql-tools'
 
 import { UserModel } from '../mongo'
-import { UserDocument } from '../mongo/User'
-import { encodeModelID } from '../utils/graphqlID'
+import { globalIdField } from '../utils/graphqlID'
 
 export const root: IResolvers = {
   User: {
-    id: (root: UserDocument) => encodeModelID('User', root._id),
+    id: globalIdField(),
   },
 }
 

--- a/api/src/resolvers/user.ts
+++ b/api/src/resolvers/user.ts
@@ -3,10 +3,11 @@ import { IResolverObject, IResolvers } from 'graphql-tools'
 
 import { UserModel } from '../mongo'
 import { UserDocument } from '../mongo/User'
+import { encodeModelID } from '../utils/graphqlID'
 
 export const root: IResolvers = {
   User: {
-    id: (root: UserDocument) => root._id.toString(),
+    id: (root: UserDocument) => encodeModelID('User', root._id),
   },
 }
 

--- a/api/src/utils/graphqlID.ts
+++ b/api/src/utils/graphqlID.ts
@@ -1,0 +1,34 @@
+import { Types } from 'mongoose'
+
+type Version = '01'
+
+const supportedVersions: Version[] = ['01']
+const currentVersion: Version = '01'
+
+const isSupportedVersion = (version: string): version is Version => {
+  return (supportedVersions as string[]).includes(version)
+}
+
+const decoders: {
+  [version in Version]: (str: string) => [string, string]
+} = {
+  '01': (modelId: string) => {
+    const [objectTypeName, objectId] = modelId.split(':')
+
+    return [objectTypeName, objectId]
+  },
+}
+
+export const encodeModelID = (name: string, id: Types.ObjectId) => {
+  return Buffer.from(`${currentVersion}@${name}:${id}`).toString('base64')
+}
+
+export const decodeModelId = (id: string) => {
+  const [version, modelId] = Buffer.from(id, 'base64').toString().split('@')
+
+  if (!isSupportedVersion(version)) {
+    throw new Error(`Unsupported model ID version: "${version}"`)
+  }
+
+  return decoders[version](modelId)
+}

--- a/api/src/utils/graphqlID.ts
+++ b/api/src/utils/graphqlID.ts
@@ -10,12 +10,12 @@ const isSupportedVersion = (version: string): version is Version => {
 }
 
 const decoders: {
-  [version in Version]: (str: string) => [string, string]
+  [version in Version]: (str: string) => { typeName: string; objectId: string }
 } = {
   '01': (modelId: string) => {
     const [objectTypeName, objectId] = modelId.split(':')
 
-    return [objectTypeName, objectId]
+    return { typeName: objectTypeName, objectId }
   },
 }
 

--- a/api/src/utils/graphqlID.ts
+++ b/api/src/utils/graphqlID.ts
@@ -1,3 +1,4 @@
+import { IFieldResolver } from 'graphql-tools'
 import { Types } from 'mongoose'
 
 type Version = '01'
@@ -19,7 +20,7 @@ const decoders: {
   },
 }
 
-export const encodeModelID = (name: string, id: Types.ObjectId) => {
+export const encodeModelId = (name: string, id: Types.ObjectId) => {
   return Buffer.from(`${currentVersion}@${name}:${id}`).toString('base64')
 }
 
@@ -31,4 +32,12 @@ export const decodeModelId = (id: string) => {
   }
 
   return decoders[version](modelId)
+}
+
+export const globalIdField = (
+  typeName?: string
+): IFieldResolver<{ _id: Types.ObjectId }, Context> => {
+  return (root, _, __, info) => {
+    return encodeModelId(typeName ?? info.parentType.name, root._id)
+  }
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
-    "target": "es6",
+    "target": "es2017",
     "strict": true,
     "outDir": "dist"
   },

--- a/app/schema.json
+++ b/app/schema.json
@@ -14,6 +14,33 @@
         "description": "App queries",
         "fields": [
           {
+            "name": "node",
+            "description": "",
+            "args": [
+              {
+                "name": "id",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "decks",
             "description": "Retrieve all decks for the logged user",
             "args": [],
@@ -207,6 +234,49 @@
         "possibleTypes": null
       },
       {
+        "kind": "SCALAR",
+        "name": "ID",
+        "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "Node",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "User",
+            "ofType": null
+          }
+        ]
+      },
+      {
         "kind": "OBJECT",
         "name": "Deck",
         "description": "Collection of notes",
@@ -314,16 +384,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "ID",
-        "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -614,7 +674,13 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [],
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },


### PR DESCRIPTION
This PR adds the `Node` GraphQL interface, alongside a `node(id: ID!): Node` query and a mechanism to convert any type `id` field to a global ID, following [GraphQL Best Practices](https://graphql.org/learn/global-object-identification/).

I added the `User` type as an implementation of the `Node` to test these changes.

One restriction to the globalId mechanism is that the typeName of the object type must *equals* to the model underlying collection name. E.g., for the user type, the model name is `User` and the typeName is `User`, so it works ootb, but for types like `Card` and `CardModel` we are required to change either the collection name or the typeName.