### PR TITLE
Fix add deck form creating duplicate decks on submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Back arrow not working in home for initial page.
 - Top bar position on mobile view.
 - Editor losing focus when clicking on any style button.
+- Add deck form creating duplicate decks.
 
 ### Removed
 - Search bar from top bar.

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -21,16 +21,6 @@ module.exports = {
   moduleNameMapper: {
     '^react-native$': 'react-native-web',
     '^.+\\.global\\.(css|sass|scss)$': 'identity-obj-proxy',
-    '^hooks/(.*)': '<rootDir>/src/hooks/$1',
-    '^assets/(.*)': '<rootDir>/src/assets/$1',
-    '^notification/(.*)': '<rootDir>/src/notification/$1',
-    '^utils/(.*)': '<rootDir>/src/utils/$1',
-    '^components/(.*)': '<rootDir>/src/components/$1',
-    '^views/(.*)': '<rootDir>/src/components/views/$1',
-    '^forms/(.*)': '<rootDir>/src/components/forms/$1',
-    '^pages/(.*)': '<rootDir>/src/components/pages/$1',
-    '^routes/(.*)': '<rootDir>/src/components/routes/$1',
-    '^resolvers/(.*)': '<rootDir>/src/resolvers/$1',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'jsx', 'node'],
 }

--- a/app/src/components/forms/AddDeckForm.tsx
+++ b/app/src/components/forms/AddDeckForm.tsx
@@ -96,22 +96,15 @@ const AddDeckForm: React.FunctionComponent<Props> = ({ open, onClose }) => {
       }}
     >
       {({ isValid, handleSubmit, isSubmitting }) => {
-        const handleClose = () => {
-          onClose()
-        }
-
-        const handleCreate = () => {
-          handleSubmit()
-        }
-
         return (
           <Dialog
             isOpen={open}
-            onDismiss={handleClose}
+            onDismiss={onClose}
             style={{ width: '320px' }}
+            aria-labelledby="add-deck-dialog-title"
           >
             <form onSubmit={handleSubmit}>
-              <DialogTitle>
+              <DialogTitle id="add-deck-dialog-title">
                 <Trans>Add Deck</Trans>
               </DialogTitle>
               <div className="flex flex-column">
@@ -131,7 +124,6 @@ const AddDeckForm: React.FunctionComponent<Props> = ({ open, onClose }) => {
                 <Button
                   type="submit"
                   disabled={!isValid || isSubmitting}
-                  onClick={handleCreate}
                   className="self-end mt3"
                 >
                   <Trans>Create</Trans>

--- a/app/src/components/forms/__tests__/AddDeckForm.test.tsx
+++ b/app/src/components/forms/__tests__/AddDeckForm.test.tsx
@@ -7,11 +7,7 @@ import { MemoryRouter } from 'react-router'
 
 import AddDeckForm, { CREATE_DECK_MUTATION } from '../AddDeckForm'
 
-interface Options {
-  mutationMocks?: MockedResponse[]
-}
-
-const render = (ui: React.ReactElement, options: Options = {}) => {
+const render = (ui: React.ReactElement) => {
   const deckMock = {
     id: 'id',
     slug: 'id',
@@ -19,24 +15,22 @@ const render = (ui: React.ReactElement, options: Options = {}) => {
     description: '',
   }
 
-  const {
-    mutationMocks = [
-      {
-        request: {
-          query: CREATE_DECK_MUTATION,
-          variables: {
-            title: deckMock.title,
-            description: '',
-          },
-        },
-        result: {
-          data: {
-            createDeck: deckMock,
-          },
+  const mocks: MockedResponse[] = [
+    {
+      request: {
+        query: CREATE_DECK_MUTATION,
+        variables: {
+          title: deckMock.title,
+          description: '',
         },
       },
-    ],
-  } = options
+      result: {
+        data: {
+          createDeck: deckMock,
+        },
+      },
+    },
+  ]
 
   const i18n = setupI18n()
 
@@ -45,7 +39,7 @@ const render = (ui: React.ReactElement, options: Options = {}) => {
   const utils = rtlRender(
     <MemoryRouter>
       <I18nProvider i18n={i18n}>
-        <MockedProvider mocks={mutationMocks} addTypename={false}>
+        <MockedProvider mocks={mocks} addTypename={false}>
           {ui}
         </MockedProvider>
       </I18nProvider>
@@ -92,7 +86,7 @@ describe('<AddDeckForm />', () => {
       expect(submitButton).toBeEnabled()
     })
 
-    fireEvent.keyPress(titleInput, { key: 'Enter', code: 13 })
+    fireEvent.submit(titleInput)
 
     await waitFor(() => {
       expect(closeCallback).toHaveBeenCalledTimes(1)

--- a/app/src/components/forms/__tests__/AddDeckForm.test.tsx
+++ b/app/src/components/forms/__tests__/AddDeckForm.test.tsx
@@ -1,7 +1,7 @@
 import { MockedProvider, MockedResponse } from '@apollo/react-testing'
 import { setupI18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
-import { fireEvent, render as rtlRender, wait } from '@testing-library/react'
+import { fireEvent, render as rtlRender, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
@@ -59,11 +59,7 @@ const render = (ui: React.ReactElement, options: Options = {}) => {
 }
 
 describe('<AddDeckForm />', () => {
-  beforeEach(() => {
-    //jest.useFakeTimers()
-  })
-
-  it('should add deck on submit click', () => {
+  it('should add deck on submit click', async () => {
     const closeCallback = jest.fn()
     const { getByLabelText, getByText, deckMock } = render(
       <AddDeckForm open onClose={closeCallback} />
@@ -74,14 +70,14 @@ describe('<AddDeckForm />', () => {
 
     fireEvent.input(titleInput, { target: { value: deckMock.title } })
 
-    wait(() => expect(submitButton).toBeEnabled())
+    await waitFor(() => expect(submitButton).toBeEnabled())
 
     fireEvent.click(submitButton)
 
-    wait(() => expect(closeCallback).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(closeCallback).toHaveBeenCalledTimes(1))
   })
 
-  it('should add one deck on input enter', () => {
+  it('should add one deck on input enter', async () => {
     const closeCallback = jest.fn()
     const { getByLabelText, getByText, deckMock } = render(
       <AddDeckForm open onClose={closeCallback} />
@@ -92,10 +88,14 @@ describe('<AddDeckForm />', () => {
 
     fireEvent.input(titleInput, { target: { value: deckMock.title } })
 
-    wait(() => expect(submitButton).toBeEnabled())
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled()
+    })
 
     fireEvent.keyPress(titleInput, { key: 'Enter', code: 13 })
 
-    wait(() => expect(closeCallback).toHaveBeenCalledTimes(1))
+    await waitFor(() => {
+      expect(closeCallback).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/app/src/components/forms/__tests__/LoginForm.test.tsx
+++ b/app/src/components/forms/__tests__/LoginForm.test.tsx
@@ -1,6 +1,6 @@
 import { setupI18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
-import { fireEvent, render as rtlRender, wait } from '@testing-library/react'
+import { fireEvent, render as rtlRender, waitFor } from '@testing-library/react'
 import React from 'react'
 
 import LoginForm from '../LoginForm'
@@ -20,7 +20,7 @@ const render = () => {
 }
 
 describe('<LoginForm />', () => {
-  it('should show error message on failure', () => {
+  it('should show error message on failure', async () => {
     global.fetch.mockResponse('Unauthorized', {
       status: 401,
       statusText: 'Unauthorized',
@@ -33,16 +33,16 @@ describe('<LoginForm />', () => {
 
     const submitButton = getByTestId('submit-btn')
 
-    wait(() => expect(submitButton).toBeDisabled())
+    await waitFor(() => expect(submitButton).toBeDisabled())
 
     fireEvent.change(usernameInput, { target: { value: 'lucas' } })
     fireEvent.change(passwordInput, { target: { value: 'password' } })
 
-    wait(() => expect(submitButton).toBeEnabled())
+    await waitFor(() => expect(submitButton).toBeEnabled())
 
     fireEvent.click(submitButton)
 
-    wait(() =>
+    await waitFor(() =>
       expect(
         getByText(/invalid username and\/or password/i)
       ).toBeInTheDocument()

--- a/app/src/components/forms/__tests__/RegisterForm.test.tsx
+++ b/app/src/components/forms/__tests__/RegisterForm.test.tsx
@@ -1,7 +1,7 @@
 import { MockedProvider } from '@apollo/react-testing'
 import { setupI18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
-import { fireEvent, render as rtlRender, wait } from '@testing-library/react'
+import { fireEvent, render as rtlRender, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
@@ -24,15 +24,15 @@ const render = (ui: React.ReactElement<any>) => {
 }
 
 describe('<RegisterForm />', () => {
-  it('should be initially disabled', () => {
+  it('should be initially disabled', async () => {
     const { getByTestId } = render(<RegisterForm />)
 
     const submitButton = getByTestId('register-submit-btn')
 
-    expect(submitButton).toBeDisabled()
+    await waitFor(() => expect(submitButton).toBeDisabled())
   })
 
-  it('should be enabled with filled fields', () => {
+  it('should be enabled with filled fields', async () => {
     const { getByLabelText, getByTestId } = render(<RegisterForm />)
 
     const submitButton = getByTestId('register-submit-btn')
@@ -47,10 +47,10 @@ describe('<RegisterForm />', () => {
     fireEvent.change(passwordInput, { target: { value: 'hunter2' } })
     fireEvent.click(agreementCheckbox)
 
-    wait(() => expect(submitButton).toBeEnabled())
+    await waitFor(() => expect(submitButton).toBeEnabled())
   })
 
-  it('should be disabled without terms agreement', () => {
+  it('should be disabled without terms agreement', async () => {
     const { getByLabelText, getByTestId } = render(<RegisterForm />)
 
     const submitButton = getByTestId('register-submit-btn')
@@ -63,6 +63,6 @@ describe('<RegisterForm />', () => {
     fireEvent.change(emailInput, { target: { value: 'user@email.com' } })
     fireEvent.change(passwordInput, { target: { value: 'hunter2' } })
 
-    expect(submitButton).toBeDisabled()
+    await waitFor(() => expect(submitButton).toBeDisabled())
   })
 })


### PR DESCRIPTION
This also updates the tests to use `waitFor` instead of the deprecated `wait` function, and fixes the `AddDeckForm` test that was using `fireEvent.keyPress` instead of `fireEvent.submit` to submit the form while the input was focused.