### PR TITLE
Revert "fix: Template interpolation in flashCard renderer not working"

### DIFF
--- a/api/src/resolvers/contentState.ts
+++ b/api/src/resolvers/contentState.ts
@@ -1,39 +1,11 @@
 import { IResolvers } from 'graphql-tools'
 
 import { ContentStateDocument } from '../mongo/ContentState'
-import { encodeGlobalId, globalIdField } from '../utils/graphqlID'
+import { globalIdField } from '../utils/graphqlID'
 
 export const root: IResolvers = {
   ContentState: {
     id: globalIdField(),
-    entityMap: (root: ContentStateDocument) => {
-      const entityMap = root.entityMap || {}
-
-      const updatedEntityMap = Object.entries(entityMap)
-        .map(([key, value]) => {
-          if (value?.type !== 'TAG') {
-            return [key, value] as const
-          }
-
-          const encodedFieldId = encodeGlobalId('Field', (value.data as any).id)
-
-          const data = {
-            ...value.data,
-            id: encodedFieldId,
-            name: {
-              ...(value.data as any).name,
-              id: encodedFieldId,
-            },
-          }
-
-          return [key, { ...value, data }] as const
-        })
-        .reduce(
-          (obj, [key, value]) => Object.assign({}, obj, { [key]: value }),
-          {}
-        )
-
-      return updatedEntityMap
-    },
+    entityMap: (root: ContentStateDocument) => root.entityMap || {},
   },
 }


### PR DESCRIPTION
Reverts cramkle/cramkle#140

This fix only worked for templates that were created before the migration of the entities to the globalId mode, and won't work for templates created from now on. Since the app isn't running anywhere, this won't affect anyone.