### PR TITLE
chore: Prevent lint-staged from "fixing" ignored files

### DIFF
--- a/app/src/components/__generated__/DeckCard_deck.ts
+++ b/app/src/components/__generated__/DeckCard_deck.ts
@@ -8,32 +8,32 @@
 // ====================================================
 
 export interface DeckCard_deck_studySessionDetails {
-  __typename: 'StudySessionDetails'
-  newCount: number
-  learningCount: number
-  reviewCount: number
+  __typename: "StudySessionDetails";
+  newCount: number;
+  learningCount: number;
+  reviewCount: number;
 }
 
 export interface DeckCard_deck {
-  __typename: 'Deck'
+  __typename: "Deck";
   /**
    * Deck id
    */
-  id: string
+  id: string;
   /**
    * Unique identifiable slug
    */
-  slug: string
+  slug: string;
   /**
    * Title of the deck
    */
-  title: string
+  title: string;
   /**
    * Description of the deck
    */
-  description: string | null
+  description: string | null;
   /**
    * Details of current study session
    */
-  studySessionDetails: DeckCard_deck_studySessionDetails
+  studySessionDetails: DeckCard_deck_studySessionDetails;
 }

--- a/app/src/components/__generated__/DecksQuery.ts
+++ b/app/src/components/__generated__/DecksQuery.ts
@@ -8,39 +8,39 @@
 // ====================================================
 
 export interface DecksQuery_decks_studySessionDetails {
-  __typename: 'StudySessionDetails'
-  newCount: number
-  learningCount: number
-  reviewCount: number
+  __typename: "StudySessionDetails";
+  newCount: number;
+  learningCount: number;
+  reviewCount: number;
 }
 
 export interface DecksQuery_decks {
-  __typename: 'Deck'
+  __typename: "Deck";
   /**
    * Deck id
    */
-  id: string
+  id: string;
   /**
    * Unique identifiable slug
    */
-  slug: string
+  slug: string;
   /**
    * Title of the deck
    */
-  title: string
+  title: string;
   /**
    * Description of the deck
    */
-  description: string | null
+  description: string | null;
   /**
    * Details of current study session
    */
-  studySessionDetails: DecksQuery_decks_studySessionDetails
+  studySessionDetails: DecksQuery_decks_studySessionDetails;
 }
 
 export interface DecksQuery {
   /**
    * Retrieve all decks for the logged user
    */
-  decks: DecksQuery_decks[]
+  decks: DecksQuery_decks[];
 }

--- a/app/src/components/__generated__/DeleteModelMutation.ts
+++ b/app/src/components/__generated__/DeleteModelMutation.ts
@@ -8,20 +8,20 @@
 // ====================================================
 
 export interface DeleteModelMutation_deleteModel {
-  __typename: 'Model'
+  __typename: "Model";
   /**
    * Card model id
    */
-  id: string
+  id: string;
 }
 
 export interface DeleteModelMutation {
   /**
    * Deletes a model and all associated entities
    */
-  deleteModel: DeleteModelMutation_deleteModel | null
+  deleteModel: DeleteModelMutation_deleteModel | null;
 }
 
 export interface DeleteModelMutationVariables {
-  modelId: string
+  modelId: string;
 }

--- a/app/src/components/__generated__/ModelsQuery.ts
+++ b/app/src/components/__generated__/ModelsQuery.ts
@@ -8,52 +8,52 @@
 // ====================================================
 
 export interface ModelsQuery_models_templates {
-  __typename: 'Template'
+  __typename: "Template";
   /**
    * Template id
    */
-  id: string
+  id: string;
   /**
    * Name of the template
    */
-  name: string | null
+  name: string | null;
 }
 
 export interface ModelsQuery_models_fields {
-  __typename: 'Field'
+  __typename: "Field";
   /**
    * Field id
    */
-  id: string
+  id: string;
   /**
    * Name of the field
    */
-  name: string
+  name: string;
 }
 
 export interface ModelsQuery_models {
-  __typename: 'Model'
+  __typename: "Model";
   /**
    * Card model id
    */
-  id: string
+  id: string;
   /**
    * Name of this card model (e.g. "Basic", "Basic with Reversed")
    */
-  name: string | null
+  name: string | null;
   /**
    * Templates associated with this model
    */
-  templates: ModelsQuery_models_templates[]
+  templates: ModelsQuery_models_templates[];
   /**
    * Fields associated with this model
    */
-  fields: ModelsQuery_models_fields[]
+  fields: ModelsQuery_models_fields[];
 }
 
 export interface ModelsQuery {
   /**
    * Retrieve all models for the logged user
    */
-  models: ModelsQuery_models[]
+  models: ModelsQuery_models[];
 }

--- a/app/src/components/forms/__generated__/CreateDeckMutation.ts
+++ b/app/src/components/forms/__generated__/CreateDeckMutation.ts
@@ -8,44 +8,44 @@
 // ====================================================
 
 export interface CreateDeckMutation_createDeck_studySessionDetails {
-  __typename: 'StudySessionDetails'
-  newCount: number
-  learningCount: number
-  reviewCount: number
+  __typename: "StudySessionDetails";
+  newCount: number;
+  learningCount: number;
+  reviewCount: number;
 }
 
 export interface CreateDeckMutation_createDeck {
-  __typename: 'Deck'
+  __typename: "Deck";
   /**
    * Deck id
    */
-  id: string
+  id: string;
   /**
    * Unique identifiable slug
    */
-  slug: string
+  slug: string;
   /**
    * Title of the deck
    */
-  title: string
+  title: string;
   /**
    * Description of the deck
    */
-  description: string | null
+  description: string | null;
   /**
    * Details of current study session
    */
-  studySessionDetails: CreateDeckMutation_createDeck_studySessionDetails
+  studySessionDetails: CreateDeckMutation_createDeck_studySessionDetails;
 }
 
 export interface CreateDeckMutation {
   /**
    * Create a deck entity
    */
-  createDeck: CreateDeckMutation_createDeck | null
+  createDeck: CreateDeckMutation_createDeck | null;
 }
 
 export interface CreateDeckMutationVariables {
-  title: string
-  description?: string | null
+  title: string;
+  description?: string | null;
 }

--- a/app/src/components/pages/__generated__/AnswerFlashCard.ts
+++ b/app/src/components/pages/__generated__/AnswerFlashCard.ts
@@ -3,27 +3,27 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { FlashCardAnswer } from './../../../globalTypes'
+import { FlashCardAnswer } from "./../../../globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AnswerFlashCard
 // ====================================================
 
 export interface AnswerFlashCard_answerFlashCard {
-  __typename: 'FlashCard'
+  __typename: "FlashCard";
   /**
    * FlashCard id.
    */
-  id: string
+  id: string;
 }
 
 export interface AnswerFlashCard {
-  answerFlashCard: AnswerFlashCard_answerFlashCard
+  answerFlashCard: AnswerFlashCard_answerFlashCard;
 }
 
 export interface AnswerFlashCardVariables {
-  noteId: string
-  flashCardId: string
-  answer: FlashCardAnswer
-  timespan: number
+  noteId: string;
+  flashCardId: string;
+  answer: FlashCardAnswer;
+  timespan: number;
 }

--- a/app/src/components/pages/__generated__/CreateModelMutation.ts
+++ b/app/src/components/pages/__generated__/CreateModelMutation.ts
@@ -3,65 +3,65 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { FieldInput, TemplateInput } from './../../../globalTypes'
+import { FieldInput, TemplateInput } from "./../../../globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CreateModelMutation
 // ====================================================
 
 export interface CreateModelMutation_createModel_templates {
-  __typename: 'Template'
+  __typename: "Template";
   /**
    * Template id
    */
-  id: string
+  id: string;
   /**
    * Name of the template
    */
-  name: string | null
+  name: string | null;
 }
 
 export interface CreateModelMutation_createModel_fields {
-  __typename: 'Field'
+  __typename: "Field";
   /**
    * Field id
    */
-  id: string
+  id: string;
   /**
    * Name of the field
    */
-  name: string
+  name: string;
 }
 
 export interface CreateModelMutation_createModel {
-  __typename: 'Model'
+  __typename: "Model";
   /**
    * Card model id
    */
-  id: string
+  id: string;
   /**
    * Name of this card model (e.g. "Basic", "Basic with Reversed")
    */
-  name: string | null
+  name: string | null;
   /**
    * Templates associated with this model
    */
-  templates: CreateModelMutation_createModel_templates[]
+  templates: CreateModelMutation_createModel_templates[];
   /**
    * Fields associated with this model
    */
-  fields: CreateModelMutation_createModel_fields[]
+  fields: CreateModelMutation_createModel_fields[];
 }
 
 export interface CreateModelMutation {
   /**
    * Create a new model
    */
-  createModel: CreateModelMutation_createModel | null
+  createModel: CreateModelMutation_createModel | null;
 }
 
 export interface CreateModelMutationVariables {
-  name: string
-  fields: FieldInput[]
-  templates: TemplateInput[]
+  name: string;
+  fields: FieldInput[];
+  templates: TemplateInput[];
 }

--- a/app/src/components/pages/__generated__/CreateNoteMutation.ts
+++ b/app/src/components/pages/__generated__/CreateNoteMutation.ts
@@ -3,29 +3,29 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { FieldValueInput } from './../../../globalTypes'
+import { FieldValueInput } from "./../../../globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CreateNoteMutation
 // ====================================================
 
 export interface CreateNoteMutation_createNote {
-  __typename: 'Note'
+  __typename: "Note";
   /**
    * Note id
    */
-  id: string
+  id: string;
 }
 
 export interface CreateNoteMutation {
   /**
    * Create new note in deck
    */
-  createNote: CreateNoteMutation_createNote | null
+  createNote: CreateNoteMutation_createNote | null;
 }
 
 export interface CreateNoteMutationVariables {
-  deckId: string
-  modelId: string
-  values: FieldValueInput[]
+  deckId: string;
+  modelId: string;
+  values: FieldValueInput[];
 }

--- a/app/src/components/pages/__generated__/DeckQuery.ts
+++ b/app/src/components/pages/__generated__/DeckQuery.ts
@@ -3,197 +3,197 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { FlashCardStatus } from './../../../globalTypes'
+import { FlashCardStatus } from "./../../../globalTypes";
 
 // ====================================================
 // GraphQL query operation: DeckQuery
 // ====================================================
 
 export interface DeckQuery_deck_notes_edges_node_model_primaryField {
-  __typename: 'Field'
+  __typename: "Field";
   /**
    * Field id
    */
-  id: string
+  id: string;
 }
 
 export interface DeckQuery_deck_notes_edges_node_model {
-  __typename: 'Model'
+  __typename: "Model";
   /**
    * Name of this card model (e.g. "Basic", "Basic with Reversed")
    */
-  name: string | null
+  name: string | null;
   /**
    * Primary field that should represent each individual note
    * of this model.
    */
-  primaryField: DeckQuery_deck_notes_edges_node_model_primaryField | null
+  primaryField: DeckQuery_deck_notes_edges_node_model_primaryField | null;
 }
 
 export interface DeckQuery_deck_notes_edges_node_flashCards_template {
-  __typename: 'Template'
+  __typename: "Template";
   /**
    * Name of the template
    */
-  name: string | null
+  name: string | null;
 }
 
 export interface DeckQuery_deck_notes_edges_node_flashCards {
-  __typename: 'FlashCard'
+  __typename: "FlashCard";
   /**
    * FlashCard id.
    */
-  id: string
+  id: string;
   /**
    * Whether to be filtered of not.
-   *
+   * 
    * Acts like a logical deletion it when comes to the review.
    */
-  active: boolean | null
+  active: boolean | null;
   /**
    * Deprecated
    */
-  state: FlashCardStatus | null
+  state: FlashCardStatus | null;
   /**
    * Due date of this flashcard, in a timestamp format.
    */
-  due: number | null
+  due: number | null;
   /**
    * Template associated with this flashcard.
    */
-  template: DeckQuery_deck_notes_edges_node_flashCards_template | null
+  template: DeckQuery_deck_notes_edges_node_flashCards_template | null;
 }
 
 export interface DeckQuery_deck_notes_edges_node_deck {
-  __typename: 'Deck'
+  __typename: "Deck";
   /**
    * Title of the deck
    */
-  title: string
+  title: string;
 }
 
 export interface DeckQuery_deck_notes_edges_node {
-  __typename: 'Note'
+  __typename: "Note";
   /**
    * Note id
    */
-  id: string
+  id: string;
   /**
    * Note text representation
    */
-  text: string
+  text: string;
   /**
    * Model of this note
    */
-  model: DeckQuery_deck_notes_edges_node_model | null
+  model: DeckQuery_deck_notes_edges_node_model | null;
   /**
    * Generated flashcards
    */
-  flashCards: DeckQuery_deck_notes_edges_node_flashCards[]
+  flashCards: DeckQuery_deck_notes_edges_node_flashCards[];
   /**
    * Deck containing this note
    */
-  deck: DeckQuery_deck_notes_edges_node_deck | null
+  deck: DeckQuery_deck_notes_edges_node_deck | null;
 }
 
 export interface DeckQuery_deck_notes_edges {
-  __typename: 'NoteEdge'
-  node: DeckQuery_deck_notes_edges_node
-  cursor: string
+  __typename: "NoteEdge";
+  node: DeckQuery_deck_notes_edges_node;
+  cursor: string;
 }
 
 export interface DeckQuery_deck_notes_pageInfo {
-  __typename: 'PageInfo'
-  hasNextPage: boolean
-  endCursor: string | null
+  __typename: "PageInfo";
+  hasNextPage: boolean;
+  endCursor: string | null;
 }
 
 export interface DeckQuery_deck_notes_pageCursors_first {
-  __typename: 'PageCursor'
-  cursor: string
-  page: number
-  isCurrent: boolean
+  __typename: "PageCursor";
+  cursor: string;
+  page: number;
+  isCurrent: boolean;
 }
 
 export interface DeckQuery_deck_notes_pageCursors_around {
-  __typename: 'PageCursor'
-  cursor: string
-  page: number
-  isCurrent: boolean
+  __typename: "PageCursor";
+  cursor: string;
+  page: number;
+  isCurrent: boolean;
 }
 
 export interface DeckQuery_deck_notes_pageCursors_last {
-  __typename: 'PageCursor'
-  cursor: string
-  page: number
-  isCurrent: boolean
+  __typename: "PageCursor";
+  cursor: string;
+  page: number;
+  isCurrent: boolean;
 }
 
 export interface DeckQuery_deck_notes_pageCursors_previous {
-  __typename: 'PageCursor'
-  cursor: string
-  page: number
-  isCurrent: boolean
+  __typename: "PageCursor";
+  cursor: string;
+  page: number;
+  isCurrent: boolean;
 }
 
 export interface DeckQuery_deck_notes_pageCursors {
-  __typename: 'PageCursors'
-  first: DeckQuery_deck_notes_pageCursors_first | null
-  around: DeckQuery_deck_notes_pageCursors_around[]
-  last: DeckQuery_deck_notes_pageCursors_last | null
-  previous: DeckQuery_deck_notes_pageCursors_previous | null
+  __typename: "PageCursors";
+  first: DeckQuery_deck_notes_pageCursors_first | null;
+  around: DeckQuery_deck_notes_pageCursors_around[];
+  last: DeckQuery_deck_notes_pageCursors_last | null;
+  previous: DeckQuery_deck_notes_pageCursors_previous | null;
 }
 
 export interface DeckQuery_deck_notes {
-  __typename: 'NoteConnection'
-  totalCount: number
-  edges: DeckQuery_deck_notes_edges[]
-  pageInfo: DeckQuery_deck_notes_pageInfo
-  pageCursors: DeckQuery_deck_notes_pageCursors
+  __typename: "NoteConnection";
+  totalCount: number;
+  edges: DeckQuery_deck_notes_edges[];
+  pageInfo: DeckQuery_deck_notes_pageInfo;
+  pageCursors: DeckQuery_deck_notes_pageCursors;
 }
 
 export interface DeckQuery_deck {
-  __typename: 'Deck'
+  __typename: "Deck";
   /**
    * Deck id
    */
-  id: string
+  id: string;
   /**
    * Unique identifiable slug
    */
-  slug: string
+  slug: string;
   /**
    * Title of the deck
    */
-  title: string
+  title: string;
   /**
    * Description of the deck
    */
-  description: string | null
+  description: string | null;
   /**
    * Number of notes in this deck
    */
-  totalNotes: number
+  totalNotes: number;
   /**
    * Number of flashCards in this deck
    */
-  totalFlashcards: number
+  totalFlashcards: number;
   /**
    * Notes contained in this deck
    */
-  notes: DeckQuery_deck_notes | null
+  notes: DeckQuery_deck_notes | null;
 }
 
 export interface DeckQuery {
   /**
    * Get single deck
    */
-  deck: DeckQuery_deck | null
+  deck: DeckQuery_deck | null;
 }
 
 export interface DeckQueryVariables {
-  slug: string
-  page: number
-  size: number
-  search?: string | null
+  slug: string;
+  page: number;
+  size: number;
+  search?: string | null;
 }

--- a/app/src/components/pages/__generated__/DecksToStudy.ts
+++ b/app/src/components/pages/__generated__/DecksToStudy.ts
@@ -8,39 +8,39 @@
 // ====================================================
 
 export interface DecksToStudy_decks_studySessionDetails {
-  __typename: 'StudySessionDetails'
-  newCount: number
-  learningCount: number
-  reviewCount: number
+  __typename: "StudySessionDetails";
+  newCount: number;
+  learningCount: number;
+  reviewCount: number;
 }
 
 export interface DecksToStudy_decks {
-  __typename: 'Deck'
+  __typename: "Deck";
   /**
    * Deck id
    */
-  id: string
+  id: string;
   /**
    * Unique identifiable slug
    */
-  slug: string
+  slug: string;
   /**
    * Title of the deck
    */
-  title: string
+  title: string;
   /**
    * Description of the deck
    */
-  description: string | null
+  description: string | null;
   /**
    * Details of current study session
    */
-  studySessionDetails: DecksToStudy_decks_studySessionDetails
+  studySessionDetails: DecksToStudy_decks_studySessionDetails;
 }
 
 export interface DecksToStudy {
   /**
    * Retrieve all decks for the logged user
    */
-  decks: DecksToStudy_decks[]
+  decks: DecksToStudy_decks[];
 }

--- a/app/src/components/pages/__generated__/DraftContent.ts
+++ b/app/src/components/pages/__generated__/DraftContent.ts
@@ -8,33 +8,33 @@
 // ====================================================
 
 export interface DraftContent_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface DraftContent_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface DraftContent_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges: (DraftContent_blocks_inlineStyleRanges | null)[] | null
-  entityRanges: (DraftContent_blocks_entityRanges | null)[] | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (DraftContent_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (DraftContent_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface DraftContent {
-  __typename: 'ContentState'
-  id: string
-  blocks: DraftContent_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: DraftContent_blocks[];
+  entityMap: any;
 }

--- a/app/src/components/pages/__generated__/FlashCards.ts
+++ b/app/src/components/pages/__generated__/FlashCards.ts
@@ -8,179 +8,167 @@
 // ====================================================
 
 export interface FlashCards_studyFlashCard_template_frontSide_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface FlashCards_studyFlashCard_template_frontSide_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface FlashCards_studyFlashCard_template_frontSide_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (FlashCards_studyFlashCard_template_frontSide_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (FlashCards_studyFlashCard_template_frontSide_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (FlashCards_studyFlashCard_template_frontSide_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (FlashCards_studyFlashCard_template_frontSide_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface FlashCards_studyFlashCard_template_frontSide {
-  __typename: 'ContentState'
-  id: string
-  blocks: FlashCards_studyFlashCard_template_frontSide_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: FlashCards_studyFlashCard_template_frontSide_blocks[];
+  entityMap: any;
 }
 
 export interface FlashCards_studyFlashCard_template_backSide_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface FlashCards_studyFlashCard_template_backSide_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface FlashCards_studyFlashCard_template_backSide_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (FlashCards_studyFlashCard_template_backSide_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (FlashCards_studyFlashCard_template_backSide_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (FlashCards_studyFlashCard_template_backSide_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (FlashCards_studyFlashCard_template_backSide_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface FlashCards_studyFlashCard_template_backSide {
-  __typename: 'ContentState'
-  id: string
-  blocks: FlashCards_studyFlashCard_template_backSide_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: FlashCards_studyFlashCard_template_backSide_blocks[];
+  entityMap: any;
 }
 
 export interface FlashCards_studyFlashCard_template {
-  __typename: 'Template'
+  __typename: "Template";
   /**
    * Front side template
    */
-  frontSide: FlashCards_studyFlashCard_template_frontSide | null
+  frontSide: FlashCards_studyFlashCard_template_frontSide | null;
   /**
    * Back side template
    */
-  backSide: FlashCards_studyFlashCard_template_backSide | null
+  backSide: FlashCards_studyFlashCard_template_backSide | null;
 }
 
 export interface FlashCards_studyFlashCard_note_values_data_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface FlashCards_studyFlashCard_note_values_data_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface FlashCards_studyFlashCard_note_values_data_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (FlashCards_studyFlashCard_note_values_data_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (FlashCards_studyFlashCard_note_values_data_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (FlashCards_studyFlashCard_note_values_data_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (FlashCards_studyFlashCard_note_values_data_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface FlashCards_studyFlashCard_note_values_data {
-  __typename: 'ContentState'
-  id: string
-  blocks: FlashCards_studyFlashCard_note_values_data_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: FlashCards_studyFlashCard_note_values_data_blocks[];
+  entityMap: any;
 }
 
 export interface FlashCards_studyFlashCard_note_values_field {
-  __typename: 'Field'
+  __typename: "Field";
   /**
    * Field id
    */
-  id: string
+  id: string;
   /**
    * Name of the field
    */
-  name: string
+  name: string;
 }
 
 export interface FlashCards_studyFlashCard_note_values {
-  __typename: 'FieldValue'
+  __typename: "FieldValue";
   /**
    * Field value id
    */
-  id: string
+  id: string;
   /**
    * Field data
    */
-  data: FlashCards_studyFlashCard_note_values_data | null
+  data: FlashCards_studyFlashCard_note_values_data | null;
   /**
    * Associated field
    */
-  field: FlashCards_studyFlashCard_note_values_field | null
+  field: FlashCards_studyFlashCard_note_values_field | null;
 }
 
 export interface FlashCards_studyFlashCard_note {
-  __typename: 'Note'
+  __typename: "Note";
   /**
    * Note id
    */
-  id: string
+  id: string;
   /**
    * Values of this note
    */
-  values: FlashCards_studyFlashCard_note_values[]
+  values: FlashCards_studyFlashCard_note_values[];
 }
 
 export interface FlashCards_studyFlashCard {
-  __typename: 'FlashCard'
+  __typename: "FlashCard";
   /**
    * FlashCard id.
    */
-  id: string
+  id: string;
   /**
    * Template associated with this flashcard.
    */
-  template: FlashCards_studyFlashCard_template | null
+  template: FlashCards_studyFlashCard_template | null;
   /**
    * Parent note of the flashcard.
    */
-  note: FlashCards_studyFlashCard_note | null
+  note: FlashCards_studyFlashCard_note | null;
 }
 
 export interface FlashCards {
@@ -188,9 +176,9 @@ export interface FlashCards {
    * Retrieves the next flashcard for a study
    * session in the given deck
    */
-  studyFlashCard: FlashCards_studyFlashCard | null
+  studyFlashCard: FlashCards_studyFlashCard | null;
 }
 
 export interface FlashCardsVariables {
-  deckSlug: string
+  deckSlug: string;
 }

--- a/app/src/components/pages/__generated__/ModelQuery.ts
+++ b/app/src/components/pages/__generated__/ModelQuery.ts
@@ -8,160 +8,152 @@
 // ====================================================
 
 export interface ModelQuery_model_fields {
-  __typename: 'Field'
+  __typename: "Field";
   /**
    * Field id
    */
-  id: string
+  id: string;
   /**
    * Name of the field
    */
-  name: string
+  name: string;
 }
 
 export interface ModelQuery_model_templates_frontSide_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface ModelQuery_model_templates_frontSide_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface ModelQuery_model_templates_frontSide_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (ModelQuery_model_templates_frontSide_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (ModelQuery_model_templates_frontSide_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (ModelQuery_model_templates_frontSide_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (ModelQuery_model_templates_frontSide_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface ModelQuery_model_templates_frontSide {
-  __typename: 'ContentState'
-  id: string
-  blocks: ModelQuery_model_templates_frontSide_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: ModelQuery_model_templates_frontSide_blocks[];
+  entityMap: any;
 }
 
 export interface ModelQuery_model_templates_backSide_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface ModelQuery_model_templates_backSide_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface ModelQuery_model_templates_backSide_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (ModelQuery_model_templates_backSide_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (ModelQuery_model_templates_backSide_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (ModelQuery_model_templates_backSide_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (ModelQuery_model_templates_backSide_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface ModelQuery_model_templates_backSide {
-  __typename: 'ContentState'
-  id: string
-  blocks: ModelQuery_model_templates_backSide_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: ModelQuery_model_templates_backSide_blocks[];
+  entityMap: any;
 }
 
 export interface ModelQuery_model_templates {
-  __typename: 'Template'
+  __typename: "Template";
   /**
    * Template id
    */
-  id: string
+  id: string;
   /**
    * Name of the template
    */
-  name: string | null
+  name: string | null;
   /**
    * Front side template
    */
-  frontSide: ModelQuery_model_templates_frontSide | null
+  frontSide: ModelQuery_model_templates_frontSide | null;
   /**
    * Back side template
    */
-  backSide: ModelQuery_model_templates_backSide | null
+  backSide: ModelQuery_model_templates_backSide | null;
 }
 
 export interface ModelQuery_model_notes_flashCards {
-  __typename: 'FlashCard'
+  __typename: "FlashCard";
   /**
    * FlashCard id.
    */
-  id: string
+  id: string;
 }
 
 export interface ModelQuery_model_notes {
-  __typename: 'Note'
+  __typename: "Note";
   /**
    * Note id
    */
-  id: string
+  id: string;
   /**
    * Generated flashcards
    */
-  flashCards: ModelQuery_model_notes_flashCards[]
+  flashCards: ModelQuery_model_notes_flashCards[];
 }
 
 export interface ModelQuery_model {
-  __typename: 'Model'
+  __typename: "Model";
   /**
    * Card model id
    */
-  id: string
+  id: string;
   /**
    * Name of this card model (e.g. "Basic", "Basic with Reversed")
    */
-  name: string | null
+  name: string | null;
   /**
    * Fields associated with this model
    */
-  fields: ModelQuery_model_fields[]
+  fields: ModelQuery_model_fields[];
   /**
    * Templates associated with this model
    */
-  templates: ModelQuery_model_templates[]
+  templates: ModelQuery_model_templates[];
   /**
    * Notes associated with this model
    */
-  notes: ModelQuery_model_notes[] | null
+  notes: ModelQuery_model_notes[] | null;
 }
 
 export interface ModelQuery {
   /**
    * Get single model
    */
-  model: ModelQuery_model | null
+  model: ModelQuery_model | null;
 }
 
 export interface ModelQueryVariables {
-  id: string
+  id: string;
 }

--- a/app/src/components/pages/__generated__/NoteFormQuery.ts
+++ b/app/src/components/pages/__generated__/NoteFormQuery.ts
@@ -8,56 +8,56 @@
 // ====================================================
 
 export interface NoteFormQuery_deck {
-  __typename: 'Deck'
+  __typename: "Deck";
   /**
    * Deck id
    */
-  id: string
+  id: string;
   /**
    * Title of the deck
    */
-  title: string
+  title: string;
 }
 
 export interface NoteFormQuery_models_fields {
-  __typename: 'Field'
+  __typename: "Field";
   /**
    * Field id
    */
-  id: string
+  id: string;
   /**
    * Name of the field
    */
-  name: string
+  name: string;
 }
 
 export interface NoteFormQuery_models {
-  __typename: 'Model'
+  __typename: "Model";
   /**
    * Card model id
    */
-  id: string
+  id: string;
   /**
    * Name of this card model (e.g. "Basic", "Basic with Reversed")
    */
-  name: string | null
+  name: string | null;
   /**
    * Fields associated with this model
    */
-  fields: NoteFormQuery_models_fields[]
+  fields: NoteFormQuery_models_fields[];
 }
 
 export interface NoteFormQuery {
   /**
    * Get single deck
    */
-  deck: NoteFormQuery_deck | null
+  deck: NoteFormQuery_deck | null;
   /**
    * Retrieve all models for the logged user
    */
-  models: NoteFormQuery_models[]
+  models: NoteFormQuery_models[];
 }
 
 export interface NoteFormQueryVariables {
-  slug: string
+  slug: string;
 }

--- a/app/src/components/pages/__generated__/NoteQuery.ts
+++ b/app/src/components/pages/__generated__/NoteQuery.ts
@@ -3,253 +3,243 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { FlashCardStatus } from './../../../globalTypes'
+import { FlashCardStatus } from "./../../../globalTypes";
 
 // ====================================================
 // GraphQL query operation: NoteQuery
 // ====================================================
 
 export interface NoteQuery_note_deck {
-  __typename: 'Deck'
+  __typename: "Deck";
   /**
    * Title of the deck
    */
-  title: string
+  title: string;
 }
 
 export interface NoteQuery_note_model_primaryField {
-  __typename: 'Field'
+  __typename: "Field";
   /**
    * Field id
    */
-  id: string
+  id: string;
 }
 
 export interface NoteQuery_note_model {
-  __typename: 'Model'
+  __typename: "Model";
   /**
    * Primary field that should represent each individual note
    * of this model.
    */
-  primaryField: NoteQuery_note_model_primaryField | null
+  primaryField: NoteQuery_note_model_primaryField | null;
 }
 
 export interface NoteQuery_note_values_data_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface NoteQuery_note_values_data_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface NoteQuery_note_values_data_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (NoteQuery_note_values_data_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges: (NoteQuery_note_values_data_blocks_entityRanges | null)[] | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (NoteQuery_note_values_data_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (NoteQuery_note_values_data_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface NoteQuery_note_values_data {
-  __typename: 'ContentState'
-  id: string
-  blocks: NoteQuery_note_values_data_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: NoteQuery_note_values_data_blocks[];
+  entityMap: any;
 }
 
 export interface NoteQuery_note_values_field {
-  __typename: 'Field'
+  __typename: "Field";
   /**
    * Field id
    */
-  id: string
+  id: string;
   /**
    * Name of the field
    */
-  name: string
+  name: string;
 }
 
 export interface NoteQuery_note_values {
-  __typename: 'FieldValue'
+  __typename: "FieldValue";
   /**
    * Field value id
    */
-  id: string
+  id: string;
   /**
    * Field data
    */
-  data: NoteQuery_note_values_data | null
+  data: NoteQuery_note_values_data | null;
   /**
    * Associated field
    */
-  field: NoteQuery_note_values_field | null
+  field: NoteQuery_note_values_field | null;
 }
 
 export interface NoteQuery_note_flashCards_template_frontSide_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface NoteQuery_note_flashCards_template_frontSide_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface NoteQuery_note_flashCards_template_frontSide_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (NoteQuery_note_flashCards_template_frontSide_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (NoteQuery_note_flashCards_template_frontSide_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (NoteQuery_note_flashCards_template_frontSide_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (NoteQuery_note_flashCards_template_frontSide_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface NoteQuery_note_flashCards_template_frontSide {
-  __typename: 'ContentState'
-  id: string
-  blocks: NoteQuery_note_flashCards_template_frontSide_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: NoteQuery_note_flashCards_template_frontSide_blocks[];
+  entityMap: any;
 }
 
 export interface NoteQuery_note_flashCards_template_backSide_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface NoteQuery_note_flashCards_template_backSide_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface NoteQuery_note_flashCards_template_backSide_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (NoteQuery_note_flashCards_template_backSide_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (NoteQuery_note_flashCards_template_backSide_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (NoteQuery_note_flashCards_template_backSide_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (NoteQuery_note_flashCards_template_backSide_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface NoteQuery_note_flashCards_template_backSide {
-  __typename: 'ContentState'
-  id: string
-  blocks: NoteQuery_note_flashCards_template_backSide_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: NoteQuery_note_flashCards_template_backSide_blocks[];
+  entityMap: any;
 }
 
 export interface NoteQuery_note_flashCards_template {
-  __typename: 'Template'
+  __typename: "Template";
   /**
    * Name of the template
    */
-  name: string | null
+  name: string | null;
   /**
    * Front side template
    */
-  frontSide: NoteQuery_note_flashCards_template_frontSide | null
+  frontSide: NoteQuery_note_flashCards_template_frontSide | null;
   /**
    * Back side template
    */
-  backSide: NoteQuery_note_flashCards_template_backSide | null
+  backSide: NoteQuery_note_flashCards_template_backSide | null;
 }
 
 export interface NoteQuery_note_flashCards {
-  __typename: 'FlashCard'
+  __typename: "FlashCard";
   /**
    * FlashCard id.
    */
-  id: string
+  id: string;
   /**
    * Whether to be filtered of not.
-   *
+   * 
    * Acts like a logical deletion it when comes to the review.
    */
-  active: boolean | null
+  active: boolean | null;
   /**
    * Number of times the user has forgotten the answer
    * to this flashcard.
    */
-  lapses: number | null
+  lapses: number | null;
   /**
    * Due date of this flashcard, in a timestamp format.
    */
-  due: number | null
+  due: number | null;
   /**
    * Deprecated
    */
-  state: FlashCardStatus | null
+  state: FlashCardStatus | null;
   /**
    * Template associated with this flashcard.
    */
-  template: NoteQuery_note_flashCards_template | null
+  template: NoteQuery_note_flashCards_template | null;
 }
 
 export interface NoteQuery_note {
-  __typename: 'Note'
+  __typename: "Note";
   /**
    * Note id
    */
-  id: string
+  id: string;
   /**
    * Note text representation
    */
-  text: string
+  text: string;
   /**
    * Deck containing this note
    */
-  deck: NoteQuery_note_deck | null
+  deck: NoteQuery_note_deck | null;
   /**
    * Model of this note
    */
-  model: NoteQuery_note_model | null
+  model: NoteQuery_note_model | null;
   /**
    * Values of this note
    */
-  values: NoteQuery_note_values[]
+  values: NoteQuery_note_values[];
   /**
    * Generated flashcards
    */
-  flashCards: NoteQuery_note_flashCards[]
+  flashCards: NoteQuery_note_flashCards[];
 }
 
 export interface NoteQuery {
   /**
    * Get single note
    */
-  note: NoteQuery_note | null
+  note: NoteQuery_note | null;
 }
 
 export interface NoteQueryVariables {
-  noteId: string
+  noteId: string;
 }

--- a/app/src/components/pages/__generated__/RequestPasswordReset.ts
+++ b/app/src/components/pages/__generated__/RequestPasswordReset.ts
@@ -8,17 +8,17 @@
 // ====================================================
 
 export interface RequestPasswordReset_requestPasswordReset {
-  __typename: 'RequestPasswordResetPayload'
-  success: boolean
+  __typename: "RequestPasswordResetPayload";
+  success: boolean;
 }
 
 export interface RequestPasswordReset {
   /**
    * Request a user password reset given an email
    */
-  requestPasswordReset: RequestPasswordReset_requestPasswordReset
+  requestPasswordReset: RequestPasswordReset_requestPasswordReset;
 }
 
 export interface RequestPasswordResetVariables {
-  email: string
+  email: string;
 }

--- a/app/src/components/pages/__generated__/ResetPassword.ts
+++ b/app/src/components/pages/__generated__/ResetPassword.ts
@@ -8,20 +8,20 @@
 // ====================================================
 
 export interface ResetPassword_resetPassword {
-  __typename: 'ResetPasswordPayload'
-  success: boolean
+  __typename: "ResetPasswordPayload";
+  success: boolean;
 }
 
 export interface ResetPassword {
   /**
    * Reset the user's password
    */
-  resetPassword: ResetPassword_resetPassword
+  resetPassword: ResetPassword_resetPassword;
 }
 
 export interface ResetPasswordVariables {
-  userId: string
-  token: string
-  timestamp: string
-  newPassword: string
+  userId: string;
+  token: string;
+  timestamp: string;
+  newPassword: string;
 }

--- a/app/src/components/pages/__generated__/UpdateFieldValue.ts
+++ b/app/src/components/pages/__generated__/UpdateFieldValue.ts
@@ -3,69 +3,65 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ContentStateInput } from './../../../globalTypes'
+import { ContentStateInput } from "./../../../globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateFieldValue
 // ====================================================
 
 export interface UpdateFieldValue_updateFieldValue_data_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface UpdateFieldValue_updateFieldValue_data_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface UpdateFieldValue_updateFieldValue_data_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (UpdateFieldValue_updateFieldValue_data_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (UpdateFieldValue_updateFieldValue_data_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (UpdateFieldValue_updateFieldValue_data_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (UpdateFieldValue_updateFieldValue_data_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface UpdateFieldValue_updateFieldValue_data {
-  __typename: 'ContentState'
-  id: string
-  blocks: UpdateFieldValue_updateFieldValue_data_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: UpdateFieldValue_updateFieldValue_data_blocks[];
+  entityMap: any;
 }
 
 export interface UpdateFieldValue_updateFieldValue {
-  __typename: 'FieldValue'
+  __typename: "FieldValue";
   /**
    * Field value id
    */
-  id: string
+  id: string;
   /**
    * Field data
    */
-  data: UpdateFieldValue_updateFieldValue_data | null
+  data: UpdateFieldValue_updateFieldValue_data | null;
 }
 
 export interface UpdateFieldValue {
   /**
    * Update the field value of a note
    */
-  updateFieldValue: UpdateFieldValue_updateFieldValue | null
+  updateFieldValue: UpdateFieldValue_updateFieldValue | null;
 }
 
 export interface UpdateFieldValueVariables {
-  noteId: string
-  fieldId: string
-  data: ContentStateInput
+  noteId: string;
+  fieldId: string;
+  data: ContentStateInput;
 }

--- a/app/src/components/pages/__generated__/UpdateTemplateBackContentMutation.ts
+++ b/app/src/components/pages/__generated__/UpdateTemplateBackContentMutation.ts
@@ -3,68 +3,64 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ContentStateInput } from './../../../globalTypes'
+import { ContentStateInput } from "./../../../globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateTemplateBackContentMutation
 // ====================================================
 
 export interface UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface UpdateTemplateBackContentMutation_updateTemplate_backSide {
-  __typename: 'ContentState'
-  id: string
-  blocks: UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: UpdateTemplateBackContentMutation_updateTemplate_backSide_blocks[];
+  entityMap: any;
 }
 
 export interface UpdateTemplateBackContentMutation_updateTemplate {
-  __typename: 'Template'
+  __typename: "Template";
   /**
    * Template id
    */
-  id: string
+  id: string;
   /**
    * Back side template
    */
-  backSide: UpdateTemplateBackContentMutation_updateTemplate_backSide | null
+  backSide: UpdateTemplateBackContentMutation_updateTemplate_backSide | null;
 }
 
 export interface UpdateTemplateBackContentMutation {
   /**
    * Updates an existing template
    */
-  updateTemplate: UpdateTemplateBackContentMutation_updateTemplate | null
+  updateTemplate: UpdateTemplateBackContentMutation_updateTemplate | null;
 }
 
 export interface UpdateTemplateBackContentMutationVariables {
-  id: string
-  content?: ContentStateInput | null
+  id: string;
+  content?: ContentStateInput | null;
 }

--- a/app/src/components/pages/__generated__/UpdateTemplateFrontContentMutation.ts
+++ b/app/src/components/pages/__generated__/UpdateTemplateFrontContentMutation.ts
@@ -3,68 +3,64 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ContentStateInput } from './../../../globalTypes'
+import { ContentStateInput } from "./../../../globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateTemplateFrontContentMutation
 // ====================================================
 
 export interface UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks_inlineStyleRanges {
-  __typename: 'InlineStyleRange'
-  style: string | null
-  offset: number | null
-  length: number | null
+  __typename: "InlineStyleRange";
+  style: string | null;
+  offset: number | null;
+  length: number | null;
 }
 
 export interface UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks_entityRanges {
-  __typename: 'EntityRange'
-  key: number
-  length: number
-  offset: number
+  __typename: "EntityRange";
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks {
-  __typename: 'Block'
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges:
-    | (UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks_inlineStyleRanges | null)[]
-    | null
-  entityRanges:
-    | (UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks_entityRanges | null)[]
-    | null
-  data: any | null
+  __typename: "Block";
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges: (UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks_inlineStyleRanges | null)[] | null;
+  entityRanges: (UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks_entityRanges | null)[] | null;
+  data: any | null;
 }
 
 export interface UpdateTemplateFrontContentMutation_updateTemplate_frontSide {
-  __typename: 'ContentState'
-  id: string
-  blocks: UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks[]
-  entityMap: any
+  __typename: "ContentState";
+  id: string;
+  blocks: UpdateTemplateFrontContentMutation_updateTemplate_frontSide_blocks[];
+  entityMap: any;
 }
 
 export interface UpdateTemplateFrontContentMutation_updateTemplate {
-  __typename: 'Template'
+  __typename: "Template";
   /**
    * Template id
    */
-  id: string
+  id: string;
   /**
    * Front side template
    */
-  frontSide: UpdateTemplateFrontContentMutation_updateTemplate_frontSide | null
+  frontSide: UpdateTemplateFrontContentMutation_updateTemplate_frontSide | null;
 }
 
 export interface UpdateTemplateFrontContentMutation {
   /**
    * Updates an existing template
    */
-  updateTemplate: UpdateTemplateFrontContentMutation_updateTemplate | null
+  updateTemplate: UpdateTemplateFrontContentMutation_updateTemplate | null;
 }
 
 export interface UpdateTemplateFrontContentMutationVariables {
-  id: string
-  content?: ContentStateInput | null
+  id: string;
+  content?: ContentStateInput | null;
 }

--- a/app/src/globalTypes.ts
+++ b/app/src/globalTypes.ts
@@ -8,57 +8,57 @@
 //==============================================================
 
 export enum FlashCardAnswer {
-  EASY = 'EASY',
-  GOOD = 'GOOD',
-  HARD = 'HARD',
-  REPEAT = 'REPEAT',
+  EASY = "EASY",
+  GOOD = "GOOD",
+  HARD = "HARD",
+  REPEAT = "REPEAT",
 }
 
 export enum FlashCardStatus {
-  LEARNING = 'LEARNING',
-  NEW = 'NEW',
-  REVIEW = 'REVIEW',
+  LEARNING = "LEARNING",
+  NEW = "NEW",
+  REVIEW = "REVIEW",
 }
 
 export interface BlockInput {
-  key: string
-  type: string
-  text: string
-  depth: number
-  inlineStyleRanges?: (InlineStyleRangeInput | null)[] | null
-  entityRanges?: (EntityRangeInput | null)[] | null
-  data?: any | null
+  key: string;
+  type: string;
+  text: string;
+  depth: number;
+  inlineStyleRanges?: (InlineStyleRangeInput | null)[] | null;
+  entityRanges?: (EntityRangeInput | null)[] | null;
+  data?: any | null;
 }
 
 export interface ContentStateInput {
-  blocks: BlockInput[]
-  entityMap?: any | null
+  blocks: BlockInput[];
+  entityMap?: any | null;
 }
 
 export interface EntityRangeInput {
-  key: number
-  length: number
-  offset: number
+  key: number;
+  length: number;
+  offset: number;
 }
 
 export interface FieldInput {
-  id?: string | null
-  name?: string | null
+  id?: string | null;
+  name?: string | null;
 }
 
 export interface FieldValueInput {
-  data?: ContentStateInput | null
-  field?: FieldInput | null
+  data?: ContentStateInput | null;
+  field?: FieldInput | null;
 }
 
 export interface InlineStyleRangeInput {
-  style?: string | null
-  offset?: number | null
-  length?: number | null
+  style?: string | null;
+  offset?: number | null;
+  length?: number | null;
 }
 
 export interface TemplateInput {
-  name: string
+  name: string;
 }
 
 //==============================================================

--- a/app/src/locales/en/messages.d.ts
+++ b/app/src/locales/en/messages.d.ts
@@ -1,3 +1,3 @@
-import { AllMessages } from '@lingui/core'
-declare const messages: AllMessages
-export = messages
+import { AllMessages } from '@lingui/core';
+declare const messages: AllMessages;
+export = messages;

--- a/app/src/locales/pt/messages.d.ts
+++ b/app/src/locales/pt/messages.d.ts
@@ -1,3 +1,3 @@
-import { AllMessages } from '@lingui/core'
-declare const messages: AllMessages
-export = messages
+import { AllMessages } from '@lingui/core';
+declare const messages: AllMessages;
+export = messages;

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [
-      "eslint --fix",
-      "prettier --write"
+      "eslint --fix"
     ],
     "*.{json,graphql,gql}": [
       "prettier --write"


### PR DESCRIPTION
removing the `prettier --write` line from `lint-staged` config is "safe" because eslint already fixes prettier problems (with the `eslint-plugin-prettier`) and will ignore by default the files we don't want any linting (generated GraphQL declaration files and others).

this is pretty nice because we won't get a bunch of files changed now if we execute `yarn --cwd app gen-types` or `yarn --cwd app compile` because of the prettier differences. it also reduces the chances for conflicts if someone forget to install the root folder dependencies.