### PR TITLE
Remove primaryField from deck page query

### DIFF
--- a/src/components/pages/DeckPage.tsx
+++ b/src/components/pages/DeckPage.tsx
@@ -44,9 +44,6 @@ export const DECK_QUERY = gql`
             text
             model {
               name
-              primaryField {
-                id
-              }
             }
             flashCards {
               id

--- a/src/components/pages/__generated__/DeckQuery.ts
+++ b/src/components/pages/__generated__/DeckQuery.ts
@@ -9,24 +9,12 @@ import { FlashCardStatus } from "./../../../globalTypes";
 // GraphQL query operation: DeckQuery
 // ====================================================
 
-export interface DeckQuery_deck_notes_edges_node_model_primaryField {
-  __typename: "Field";
-  /**
-   * The ID of an object
-   */
-  id: string;
-}
-
 export interface DeckQuery_deck_notes_edges_node_model {
   __typename: "Model";
   /**
    * Name of this card model (e.g. "Basic", "Basic with Reversed")
    */
   name: string | null;
-  /**
-   * Primary field that should represent each individual note of this model.
-   */
-  primaryField: DeckQuery_deck_notes_edges_node_model_primaryField | null;
 }
 
 export interface DeckQuery_deck_notes_edges_node_flashCards_template {

--- a/src/components/pages/__tests__/DeckPage.test.tsx
+++ b/src/components/pages/__tests__/DeckPage.test.tsx
@@ -38,7 +38,6 @@ const deckQueryResultForPage = ({
                   model: {
                     __typename: 'Model',
                     name: 'Model',
-                    primaryField: null,
                   },
                   flashCards: [],
                   deck: {


### PR DESCRIPTION
This data isn't being used anymore, so we can safely remove it.