### PR TITLE
Update models query to use totalNotes and totalFlashcards fields

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -748,7 +748,7 @@
           },
           {
             "name": "totalFlashcards",
-            "description": "Number of flashCards in this deck",
+            "description": "Number of flashcards in this deck",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1292,6 +1292,38 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "totalNotes",
+            "description": "Total number of notes associated with this model",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalFlashcards",
+            "description": "Total number of flashcards associated with this model",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1432,9 +1464,13 @@
             "description": "Associated model",
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "Model",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Model",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/components/DeckCard.tsx
+++ b/src/components/DeckCard.tsx
@@ -22,6 +22,8 @@ export const deckCardFragment = gql`
     slug
     title
     description
+    totalNotes
+    totalFlashcards
     studySessionDetails {
       newCount
       learningCount
@@ -63,7 +65,7 @@ const DeckCard: React.FunctionComponent<Props> = ({
       >
         <Headline3>{deck.title}</Headline3>
         {deck.description && <Body2>{deck.description}</Body2>}
-        {showStudySessionDetails && (
+        {showStudySessionDetails ? (
           <div className="mt-1 flex">
             {newCount > 0 && (
               <FlashCardStatusChip
@@ -96,6 +98,22 @@ const DeckCard: React.FunctionComponent<Props> = ({
               </FlashCardStatusChip>
             )}
           </div>
+        ) : (
+          <Body2 className="flex items-center">
+            {i18n._(
+              plural(deck.totalNotes, {
+                one: '# note',
+                other: '# notes',
+              })
+            )}
+            <span className="inline-block mx-1">&middot;</span>
+            {i18n._(
+              plural(deck.totalFlashcards, {
+                one: '# flashcard',
+                other: '# flashcards',
+              })
+            )}
+          </Body2>
         )}
       </CardPrimaryContent>
     </Card>

--- a/src/components/DeleteModelButton.tsx
+++ b/src/components/DeleteModelButton.tsx
@@ -21,7 +21,7 @@ import {
 import Button from './views/Button'
 
 interface Props {
-  model: { id: string; templates: {}[]; notes: {}[] }
+  model: { id: string; templates: {}[]; totalNotes: number }
 }
 
 const DELETE_MODEL_MUTATION = gql`
@@ -121,7 +121,7 @@ const DeleteModelButton: React.FunctionComponent<Props> = ({ model }) => {
           <Trans>
             Are you sure you want to delete this model?{' '}
             {i18n._(
-              plural(model.notes.length, {
+              plural(model.totalNotes, {
                 one: "There's # note",
                 other: "There're # notes",
               })

--- a/src/components/__generated__/DeckCard_deck.ts
+++ b/src/components/__generated__/DeckCard_deck.ts
@@ -33,6 +33,14 @@ export interface DeckCard_deck {
    */
   description: string | null;
   /**
+   * Number of notes in this deck
+   */
+  totalNotes: number;
+  /**
+   * Number of flashcards in this deck
+   */
+  totalFlashcards: number;
+  /**
    * Details of current study session
    */
   studySessionDetails: DeckCard_deck_studySessionDetails;

--- a/src/components/__generated__/DecksQuery.ts
+++ b/src/components/__generated__/DecksQuery.ts
@@ -33,6 +33,14 @@ export interface DecksQuery_decks {
    */
   description: string | null;
   /**
+   * Number of notes in this deck
+   */
+  totalNotes: number;
+  /**
+   * Number of flashcards in this deck
+   */
+  totalFlashcards: number;
+  /**
    * Details of current study session
    */
   studySessionDetails: DecksQuery_decks_studySessionDetails;

--- a/src/components/__tests__/DeckCard.test.tsx
+++ b/src/components/__tests__/DeckCard.test.tsx
@@ -10,9 +10,11 @@ describe('<DeckCard />', () => {
         deck={{
           __typename: 'Deck',
           id: '123',
+          slug: 'nihongo-genki',
           title: '日本語げんき',
           description: '',
-          slug: 'nihongo-genki',
+          totalNotes: 2000,
+          totalFlashcards: 3200,
           studySessionDetails: {
             __typename: 'StudySessionDetails',
             newCount: 0,

--- a/src/components/__tests__/__snapshots__/DeckCard.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DeckCard.test.tsx.snap
@@ -16,6 +16,17 @@ exports[`<DeckCard /> should match snapshot 1`] = `
         日本語げんき
       </h3>
       
+      <p
+        class="flex items-center text-secondary text-sm"
+      >
+        2,000 notes
+        <span
+          class="inline-block mx-1"
+        >
+          ·
+        </span>
+        3,200 flashcards
+      </p>
     </div>
   </div>
 </div>

--- a/src/components/forms/__generated__/CreateDeckMutation.ts
+++ b/src/components/forms/__generated__/CreateDeckMutation.ts
@@ -33,6 +33,14 @@ export interface CreateDeckMutation_createDeck_deck {
    */
   description: string | null;
   /**
+   * Number of notes in this deck
+   */
+  totalNotes: number;
+  /**
+   * Number of flashcards in this deck
+   */
+  totalFlashcards: number;
+  /**
    * Details of current study session
    */
   studySessionDetails: CreateDeckMutation_createDeck_deck_studySessionDetails;

--- a/src/components/forms/__tests__/AddDeckForm.test.tsx
+++ b/src/components/forms/__tests__/AddDeckForm.test.tsx
@@ -11,6 +11,8 @@ const deckMock = {
   slug: 'id',
   title: 'my title',
   description: '',
+  totalNotes: 0,
+  totalFlashcards: 0,
   studySessionDetails: {
     __typename: 'StudySessionDetails',
     newCount: 0,

--- a/src/components/pages/ModelPage.tsx
+++ b/src/components/pages/ModelPage.tsx
@@ -233,11 +233,6 @@ const ModelPage: React.FC = () => {
 
   const { model } = data
 
-  const totalFlashCards = model.notes.reduce(
-    (total, note) => total + note.flashCards.length,
-    0
-  )
-
   return (
     <>
       <Helmet title={model.name} />
@@ -255,14 +250,14 @@ const ModelPage: React.FC = () => {
           <Headline2 className="mt-4">{model.name}</Headline2>
           <Body2 className="mt-1">
             {i18n._(
-              plural(model.notes.length, {
+              plural(model.totalNotes, {
                 one: '# note',
                 other: '# notes',
               })
             )}{' '}
             <span className="inline-block mx-1">&middot;</span>{' '}
             {i18n._(
-              plural(totalFlashCards, {
+              plural(model.totalFlashcards, {
                 one: '# flashcard',
                 other: '# flashcards',
               })

--- a/src/components/pages/ModelQuery.ts
+++ b/src/components/pages/ModelQuery.ts
@@ -45,12 +45,8 @@ export const MODEL_QUERY = gql`
           ...DraftContent
         }
       }
-      notes {
-        id
-        flashCards {
-          id
-        }
-      }
+      totalNotes
+      totalFlashcards
     }
   }
 `

--- a/src/components/pages/StudySection.tsx
+++ b/src/components/pages/StudySection.tsx
@@ -22,7 +22,6 @@ const DECKS_TO_STUDY_QUERY = gql`
   query DecksToStudy {
     decks(studyOnly: true) {
       id
-      slug
       ...DeckCard_deck
     }
   }

--- a/src/components/pages/__generated__/DeckQuery.ts
+++ b/src/components/pages/__generated__/DeckQuery.ts
@@ -189,7 +189,7 @@ export interface DeckQuery_deck {
    */
   totalNotes: number;
   /**
-   * Number of flashCards in this deck
+   * Number of flashcards in this deck
    */
   totalFlashcards: number;
   /**

--- a/src/components/pages/__generated__/DecksToStudy.ts
+++ b/src/components/pages/__generated__/DecksToStudy.ts
@@ -33,6 +33,14 @@ export interface DecksToStudy_decks {
    */
   description: string | null;
   /**
+   * Number of notes in this deck
+   */
+  totalNotes: number;
+  /**
+   * Number of flashcards in this deck
+   */
+  totalFlashcards: number;
+  /**
    * Details of current study session
    */
   studySessionDetails: DecksToStudy_decks_studySessionDetails;

--- a/src/components/pages/__generated__/ModelQuery.ts
+++ b/src/components/pages/__generated__/ModelQuery.ts
@@ -109,26 +109,6 @@ export interface ModelQuery_model_templates {
   backSide: ModelQuery_model_templates_backSide | null;
 }
 
-export interface ModelQuery_model_notes_flashCards {
-  __typename: "FlashCard";
-  /**
-   * The ID of an object
-   */
-  id: string;
-}
-
-export interface ModelQuery_model_notes {
-  __typename: "Note";
-  /**
-   * The ID of an object
-   */
-  id: string;
-  /**
-   * Generated flashcards
-   */
-  flashCards: ModelQuery_model_notes_flashCards[];
-}
-
 export interface ModelQuery_model {
   __typename: "Model";
   /**
@@ -148,9 +128,13 @@ export interface ModelQuery_model {
    */
   templates: ModelQuery_model_templates[];
   /**
-   * Notes associated with this model
+   * Total number of notes associated with this model
    */
-  notes: ModelQuery_model_notes[];
+  totalNotes: number;
+  /**
+   * Total number of flashcards associated with this model
+   */
+  totalFlashcards: number;
 }
 
 export interface ModelQuery {


### PR DESCRIPTION
Also updates the deck card to show the total of notes and flashcards as well when not showing the study session details.