### PR TITLE
Add steps based UI for create model page

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@casterly/express": "^0.7.3",
     "@lingui/react": "3.2.3",
     "@material/icon-button": "^3.1.0",
+    "@reach/alert": "^0.13.0",
     "@reach/alert-dialog": "^0.11.2",
     "@reach/checkbox": "^0.11.2",
     "@reach/dialog": "^0.11.1",
@@ -54,6 +55,7 @@
     "@reach/tooltip": "^0.11.2",
     "@reach/visually-hidden": "^0.11.1",
     "@sentry/react": "^5.27.4",
+    "@xstate/react": "^1.2.2",
     "apollo-cache-inmemory": "^1.6.5",
     "apollo-client": "^2.6.10",
     "apollo-link": "^1.2.13",
@@ -87,6 +89,7 @@
     "serialize-javascript": "^5.0.1",
     "universal-cookie": "^4.0.3",
     "uuid": "^8.3.0",
+    "xstate": "^4.16.0",
     "yup": "^0.29.3"
   },
   "devDependencies": {

--- a/src/components/ModelFieldsForm.tsx
+++ b/src/components/ModelFieldsForm.tsx
@@ -1,0 +1,114 @@
+import { Trans, t } from '@lingui/macro'
+import { useLingui } from '@lingui/react'
+import classnames from 'classnames'
+import { FieldArray, Form, Formik } from 'formik'
+import React from 'react'
+import * as yup from 'yup'
+
+import { TextInputField } from './forms/Fields'
+import BackArrowIcon from './icons/BackArrowIcon'
+import TrashBinIcon from './icons/TrashBinIcon'
+import Button from './views/Button'
+import { Headline2 } from './views/Typography'
+
+const ModelFieldsForm: React.VFC<{
+  fields: { name: string }[]
+  onSubmit: (fields: { name: string }[]) => void
+  onGoBack: () => void
+}> = ({ fields: initialFields, onSubmit, onGoBack }) => {
+  const { i18n } = useLingui()
+
+  return (
+    <Formik
+      initialValues={{
+        fields: initialFields,
+      }}
+      validationSchema={yup.object().shape({
+        fields: yup.array(
+          yup.object().shape({
+            name: yup.string().required(i18n._(t`Field name is required`)),
+          })
+        ),
+      })}
+      onSubmit={(values) => {
+        onSubmit(values.fields)
+      }}
+    >
+      {({ values }) => (
+        <Form>
+          <FieldArray name="fields" validateOnChange={false}>
+            {({ push, remove }) => (
+              <div className="mt-4">
+                <Button size="small" type="button" onClick={onGoBack}>
+                  <BackArrowIcon />
+                </Button>
+
+                <div className="mt-6 flex items-center">
+                  <Headline2 className="text-txt text-opacity-text-primary">
+                    <Trans>Fields</Trans>
+                  </Headline2>
+                  <Button
+                    type="button"
+                    className="ml-6"
+                    size="small"
+                    onClick={() => push({ name: '' })}
+                  >
+                    <Trans>Add field</Trans>
+                  </Button>
+                </div>
+
+                <p className="mt-6 max-w-prose text-txt text-opacity-text-primary">
+                  <Trans>
+                    A model consist of both fields and templates. A field is
+                    used in a note to fill values that are used inside the
+                    template.
+                  </Trans>
+                </p>
+
+                <div className="mt-6 flex flex-col">
+                  {values.fields.map((_, index) => (
+                    <div
+                      className={classnames('flex', {
+                        'mt-4': index > 0,
+                      })}
+                      key={index}
+                    >
+                      <div className="flex items-center flex-shrink-0 justify-center h-8 w-8 md:h-10 md:w-10 rounded-full bg-secondary mt-7 text-sm md:text-base text-txt text-opacity-text-primary">
+                        {index + 1}
+                      </div>
+
+                      <div className="ml-4 flex min-w-0">
+                        <TextInputField
+                          className="min-w-0 w-full"
+                          name={`fields.${index}.name`}
+                          label={i18n._(t`Field name`)}
+                        />
+
+                        <Button
+                          type="button"
+                          variation="outline"
+                          className="ml-3 text-primary mt-7"
+                          onClick={() => remove(index)}
+                          disabled={values.fields.length <= 1}
+                          aria-label={i18n._(t`Remove field`)}
+                        >
+                          <TrashBinIcon />
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </FieldArray>
+
+          <Button className="mt-6" variation="primary" type="submit">
+            <Trans>Go to templates</Trans>
+          </Button>
+        </Form>
+      )}
+    </Formik>
+  )
+}
+
+export default ModelFieldsForm

--- a/src/components/ModelNameForm.tsx
+++ b/src/components/ModelNameForm.tsx
@@ -1,0 +1,48 @@
+import { Trans, t } from '@lingui/macro'
+import { useLingui } from '@lingui/react'
+import { Form, Formik } from 'formik'
+import React from 'react'
+import * as yup from 'yup'
+
+import { TextInputField } from './forms/Fields'
+import Button from './views/Button'
+
+const ModelNameForm: React.VFC<{
+  name: string
+  onSubmit: (name: string) => void
+}> = ({ name: initialName, onSubmit }) => {
+  const { i18n } = useLingui()
+
+  return (
+    <Formik
+      initialValues={{
+        name: initialName,
+      }}
+      validateOnBlur
+      validationSchema={yup.object().shape({
+        name: yup.string().required(i18n._(t`Name is required`)),
+      })}
+      onSubmit={(values) => {
+        onSubmit(values.name)
+      }}
+    >
+      <Form>
+        <p className="mt-6 text-txt text-opacity-text-primary">
+          <Trans>Create a name for your model.</Trans>
+        </p>
+
+        <TextInputField
+          className="mt-4 max-w-md"
+          name="name"
+          label={i18n._(t`Model name`)}
+        />
+
+        <Button className="mt-6" variation="primary" type="submit">
+          <Trans>Go to fields</Trans>
+        </Button>
+      </Form>
+    </Formik>
+  )
+}
+
+export default ModelNameForm

--- a/src/components/ModelTemplatesForm.tsx
+++ b/src/components/ModelTemplatesForm.tsx
@@ -1,0 +1,153 @@
+import { Trans, t } from '@lingui/macro'
+import { useLingui } from '@lingui/react'
+import classnames from 'classnames'
+import { FieldArray, Form, Formik } from 'formik'
+import React from 'react'
+import * as yup from 'yup'
+
+import { TextInputField } from './forms/Fields'
+import BackArrowIcon from './icons/BackArrowIcon'
+import TrashBinIcon from './icons/TrashBinIcon'
+import { Alert } from './views/Alert'
+import Button from './views/Button'
+import { Headline2 } from './views/Typography'
+
+const ModelTemplatesForm: React.VFC<{
+  templates: { name: string }[]
+  isSubmitting: boolean
+  onGoBack: () => void
+  onSubmit: (templates: { name: string }[]) => void
+  hasError: boolean
+}> = ({
+  templates: initialTemplates,
+  hasError,
+  onSubmit,
+  isSubmitting,
+  onGoBack,
+}) => {
+  const { i18n } = useLingui()
+
+  return (
+    <Formik
+      initialValues={{
+        templates: initialTemplates,
+      }}
+      validationSchema={yup.object().shape({
+        templates: yup.array(
+          yup.object().shape({
+            name: yup.string().required(i18n._(t`Template name is required`)),
+          })
+        ),
+      })}
+      onSubmit={(values) => {
+        onSubmit(values.templates)
+      }}
+    >
+      {({ values }) => (
+        <Form className="flex flex-col">
+          <FieldArray name="templates" validateOnChange={false}>
+            {({ push, remove }) => (
+              <div className="mt-4 sm:pr-4">
+                <Button type="button" size="small" onClick={onGoBack}>
+                  <BackArrowIcon />
+                </Button>
+
+                <div className="mt-6 flex items-center">
+                  <Headline2 className="text-txt text-opacity-text-primary">
+                    <Trans>Templates</Trans>
+                  </Headline2>
+
+                  <Button
+                    size="small"
+                    className="ml-6"
+                    onClick={() => push({ name: '' })}
+                    type="button"
+                  >
+                    <Trans>Add template</Trans>
+                  </Button>
+                </div>
+
+                <p className="mt-6 max-w-prose text-txt text-opacity-text-primary">
+                  <Trans>
+                    The templates are used to define the frontside and backside
+                    of each flashcard, using the fields defined in the previous
+                    step. You'll be able to edit the template's content after
+                    creating the model.
+                  </Trans>
+                </p>
+
+                <p className="mt-6 max-w-prose text-txt text-opacity-text-primary">
+                  <Trans>
+                    When you create a note, we will create the corresponding
+                    number of flashcards based on how much templates the note's
+                    model has, and will use the note's values to fill in the
+                    template.
+                  </Trans>
+                </p>
+
+                <div className="mt-6 flex flex-col">
+                  {values.templates.map((_, index) => (
+                    <div
+                      className={classnames('flex', {
+                        'mt-4': index > 0,
+                      })}
+                      key={index}
+                    >
+                      <div className="flex items-center flex-shrink-0 justify-center h-10 w-10 rounded-full bg-secondary mt-7 text-txt text-opacity-text-primary">
+                        {index + 1}
+                      </div>
+
+                      <div className="ml-4 flex min-w-0">
+                        <TextInputField
+                          className="min-w-0 w-full"
+                          name={`templates.${index}.name`}
+                          label={i18n._(t`Template name`)}
+                        />
+
+                        <Button
+                          type="button"
+                          variation="outline"
+                          className="ml-3 text-primary mt-7"
+                          onClick={() => remove(index)}
+                          disabled={values.templates.length <= 1}
+                          aria-label={i18n._(t`Remove template`)}
+                        >
+                          <TrashBinIcon />
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </FieldArray>
+
+          <Button
+            className="self-start mt-6"
+            variation="primary"
+            type="submit"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <Trans>Creating model...</Trans>
+            ) : (
+              <Trans>Create model</Trans>
+            )}
+          </Button>
+
+          {hasError && (
+            <Alert className="mt-6 self-start" type="assertive" mode="warning">
+              <p>
+                {i18n._(
+                  t`An error has occurred when creating your model. Submit the form to try again`
+                )}
+              </p>
+            </Alert>
+          )}
+        </Form>
+      )}
+    </Formik>
+  )
+}
+
+export default ModelTemplatesForm

--- a/src/components/StepTab.tsx
+++ b/src/components/StepTab.tsx
@@ -1,0 +1,44 @@
+import { Trans } from '@lingui/macro'
+import { forwardRefWithAs } from '@reach/utils'
+import classnames from 'classnames'
+
+const StepTab = forwardRefWithAs<
+  { isActive?: boolean; children?: React.ReactNode; index: number },
+  'button'
+>(function StepTab(
+  { children, className = '', isActive = false, index, ...props },
+  ref
+) {
+  return (
+    <button
+      {...props}
+      type="button"
+      ref={ref}
+      role="presentation"
+      className={classnames(
+        className,
+        'group outline-reset font-medium text-sm relative capitalize px-0 py-4 inline-flex justify-start items-center border-solid border-l-0 border-r-0 border-b-0 border-t-4 cursor-default',
+        {
+          'border-primary': isActive,
+          'border-secondary': !isActive,
+        }
+      )}
+    >
+      <div className="flex flex-col text-left">
+        <span
+          className={classnames('uppercase text-sm font-semibold', {
+            'text-primary': isActive,
+            'text-txt text-opacity-text-disabled': !isActive,
+          })}
+        >
+          <Trans>Step {index + 1}</Trans>
+        </span>
+        <span className="inline-block mt-1 text-txt text-opacity-text-primary">
+          {children}
+        </span>
+      </div>
+    </button>
+  )
+})
+
+export default StepTab

--- a/src/components/pages/AddModelPage.css
+++ b/src/components/pages/AddModelPage.css
@@ -1,3 +1,0 @@
-.evenColumn {
-  flex: 1;
-}

--- a/src/components/views/Alert.tsx
+++ b/src/components/views/Alert.tsx
@@ -1,0 +1,55 @@
+import { t } from '@lingui/macro'
+import { useLingui } from '@lingui/react'
+import {
+  Alert as ReachAlert,
+  AlertProps as ReachAlertProps,
+} from '@reach/alert'
+import { forwardRefWithAs } from '@reach/utils'
+import classnames from 'classnames'
+
+import DoneIcon from '../icons/DoneIcon'
+import WarningIcon from '../icons/WarningIcon'
+
+export interface AlertProps extends ReachAlertProps {
+  mode?: 'warning' | 'error' | 'success'
+}
+
+export const Alert = forwardRefWithAs<AlertProps, 'div'>(
+  ({ className, mode = 'warning', children, ...props }, ref) => {
+    const { i18n } = useLingui()
+
+    return (
+      <ReachAlert
+        className={classnames(
+          className,
+          'inline-flex items-center bg-opacity-20 rounded-full px-4 py-3 text-txt text-opacity-text-primary',
+          {
+            'bg-yellow-1': mode === 'warning',
+            'bg-green-1': mode === 'success',
+            'bg-red-1': mode === 'error',
+          }
+        )}
+        {...props}
+        ref={ref}
+      >
+        {mode === 'success' ? (
+          <DoneIcon
+            className="text-green-1 flex-shrink-0"
+            aria-label={i18n._(t`Success`)}
+          />
+        ) : (
+          <WarningIcon
+            className={classnames('flex-shrink-0', {
+              'text-yellow-1': mode === 'warning',
+              'text-red-1': mode === 'error',
+            })}
+            aria-label={
+              mode === 'warning' ? i18n._(t`Warning`) : i18n._(t`Error`)
+            }
+          />
+        )}
+        <div className="ml-3">{children}</div>
+      </ReachAlert>
+    )
+  }
+)

--- a/src/components/views/Button.tsx
+++ b/src/components/views/Button.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import { forwardRef, useState } from 'react'
+import { forwardRef } from 'react'
 import * as React from 'react'
 
 type Props = {
@@ -20,21 +20,33 @@ const Button = forwardRef<HTMLButtonElement, Props>(function Button(
 ) {
   const classes = classnames(
     className,
-    'relative rounded py-1 px-2 outline-reset overflow-hidden',
+    'relative rounded py-1 px-4 outline-reset overflow-hidden',
+    'transition-opacity ease-in-out duration-200',
     {
       'h-10': size === 'normal',
       'h-8': size === 'small',
       'font-medium': variation !== 'plain',
       'font-normal': variation === 'plain',
       'border-0': variation !== 'outline',
-      'border-2 border-primary': variation === 'outline',
+      'border-2': variation === 'outline',
+      'border-primary': variation === 'outline' && !disabled,
+      'border-disabled border-opacity-disabled':
+        variation === 'outline' && disabled,
       'text-primary':
         (variation === 'plain' || variation === 'outline') && !disabled,
       'text-on-primary': variation === 'primary' && !disabled,
       'text-txt text-opacity-text-primary':
         variation === 'secondary' && !disabled,
       'text-txt text-opacity-text-disabled': disabled,
-      'bg-primary': variation === 'primary' && !disabled,
+      'bg-primary':
+        (variation === 'primary' ||
+          variation === 'plain' ||
+          variation === 'outline') &&
+        !disabled,
+      'hover:bg-hover-overlay focus:bg-hover-overlay hover:bg-opacity-100 focus:bg-opacity-100':
+        (variation === 'primary' || variation === 'secondary') && !disabled,
+      'bg-opacity-12 hover:bg-opacity-20 focus:bg-opacity-20':
+        (variation === 'plain' || variation === 'outline') && !disabled,
       'bg-secondary bg-opacity-secondary':
         variation === 'secondary' && !disabled,
       'bg-transparent': variation === 'outline' && !disabled,
@@ -42,42 +54,8 @@ const Button = forwardRef<HTMLButtonElement, Props>(function Button(
     }
   )
 
-  const [focused, setFocused] = useState(false)
-  const [hovered, setHovered] = useState(false)
-
-  const handleFocus: React.FocusEventHandler<HTMLButtonElement> = (evt) => {
-    setFocused(true)
-    props.onFocus?.(evt)
-  }
-  const handleBlur: React.FocusEventHandler<HTMLButtonElement> = (evt) => {
-    setFocused(false)
-    props.onBlur?.(evt)
-  }
-
-  const handleMouseEnter: React.MouseEventHandler<HTMLButtonElement> = (
-    evt
-  ) => {
-    setHovered(true)
-    props.onMouseEnter?.(evt)
-  }
-  const handleMouseLeave: React.MouseEventHandler<HTMLButtonElement> = (
-    evt
-  ) => {
-    setHovered(false)
-    props.onMouseLeave?.(evt)
-  }
-
   return (
-    <button
-      {...props}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      className={classes}
-      ref={inputRef}
-      disabled={disabled}
-    >
+    <button {...props} className={classes} ref={inputRef} disabled={disabled}>
       <div
         className={classnames('relative z-0 flex items-center justify-center', {
           'text-base': size === 'normal',
@@ -86,24 +64,6 @@ const Button = forwardRef<HTMLButtonElement, Props>(function Button(
       >
         {children}
       </div>
-      <div
-        className={classnames(
-          'absolute top-0 left-0 right-0 bottom-0 transition-opacity ease-in-out duration-200 opacity-0',
-          {
-            'opacity-0': !hovered || !focused,
-            'opacity-12': (hovered || focused) && variation !== 'secondary',
-            'opacity-100': (hovered || focused) && variation === 'secondary',
-            hidden:
-              (!hovered || !focused) &&
-              variation !== 'plain' &&
-              variation !== 'outline' &&
-              variation !== 'secondary',
-            'bg-primary':
-              (variation === 'plain' || variation === 'outline') && !disabled,
-            'bg-hover-overlay bg-opacity-08': variation === 'secondary',
-          }
-        )}
-      />
     </button>
   )
 })

--- a/src/components/views/Input.css
+++ b/src/components/views/Input.css
@@ -1,3 +1,0 @@
-.label {
-  line-height: 1.143;
-}

--- a/src/components/views/Input.tsx
+++ b/src/components/views/Input.tsx
@@ -2,8 +2,6 @@ import classnames from 'classnames'
 import { ReactNode, forwardRef, useContext } from 'react'
 import * as React from 'react'
 
-import styles from './Input.css'
-
 const LabelContext = React.createContext<{ label: boolean } | undefined>(
   undefined
 )
@@ -29,10 +27,7 @@ export const Label = forwardRef<HTMLLabelElement, LabelProps>(function Label(
         })}
       >
         <span
-          className={classnames(
-            styles.label,
-            'text-txt text-opacity-text-primary text-sm'
-          )}
+          className={classnames('text-txt text-opacity-text-primary text-sm')}
         >
           {text}
         </span>
@@ -56,7 +51,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       ref={ref}
       className={classnames(
         className,
-        'bg-input text-txt text-opacity-text-primary rounded border border-divider border-opacity-divider outline-none py-2 px-4 focus:border-primary placeholder-gray-2',
+        'bg-input text-txt text-opacity-text-primary rounded border border-divider border-opacity-divider outline-none py-2 px-4 focus:border-primary placeholder-gray-2 leading-snug',
         {
           'mt-2': isLabelled,
         }

--- a/src/components/views/Tabs.tsx
+++ b/src/components/views/Tabs.tsx
@@ -10,7 +10,7 @@ import {
 } from '@reach/tabs'
 import { ForwardRefExoticComponentWithAs, forwardRefWithAs } from '@reach/utils'
 import classNames from 'classnames'
-import { HTMLAttributes, forwardRef, useState } from 'react'
+import { HTMLAttributes, forwardRef } from 'react'
 import * as React from 'react'
 
 import styles from './Tabs.css'
@@ -29,39 +29,18 @@ export const Tab = forwardRefWithAs<TabProps, 'button'>(function Tab(
   { children, className = '', ...props },
   ref
 ) {
-  const [focused, setFocused] = useState(false)
-
-  const handleBlur: React.FocusEventHandler<HTMLButtonElement> = (evt) => {
-    setFocused(false)
-    props.onBlur?.(evt)
-  }
-
-  const handleFocus: React.FocusEventHandler<HTMLButtonElement> = (evt) => {
-    setFocused(true)
-    props.onFocus?.(evt)
-  }
-
   return (
     <ReachTab
       {...props}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
       ref={ref}
       className={classNames(
         className,
         styles.tab,
-        'group outline-reset font-medium text-sm relative capitalize px-4 md:px-6 py-2 inline-flex justify-start items-center'
+        'group outline-reset font-medium text-sm relative capitalize px-4 md:px-6 py-2 inline-flex justify-start items-center border-0'
       )}
     >
       {children}
-      <div
-        className={classNames(
-          'absolute top-0 left-0 right-0 bottom-0 bg-primary opacity-0 hover:opacity-08',
-          {
-            'opacity-08': focused,
-          }
-        )}
-      />
+      <div className="absolute top-0 left-0 right-0 bottom-0 bg-primary opacity-0 hover:opacity-08 group-focus:opacity-08" />
       <div
         className={classNames(
           styles.border,

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/pages/DeckPage.tsx:178
+#: src/components/pages/DeckPage.tsx:180
 msgid "({0} notes)"
 msgstr "({0} notes)"
 
-#: src/components/pages/StatisticsPage.tsx:277
+#: src/components/pages/StatisticsPage.tsx:283
 msgid "1 month"
 msgstr "1 month"
 
-#: src/components/pages/StatisticsPage.tsx:280
+#: src/components/pages/StatisticsPage.tsx:286
 msgid "1 year"
 msgstr "1 year"
 
-#: src/components/pages/StatisticsPage.tsx:274
+#: src/components/pages/StatisticsPage.tsx:280
 msgid "7 days"
 msgstr "7 days"
 
@@ -33,9 +33,9 @@ msgstr "7 days"
 msgid "<0>Click to change password.</0> Secure your account with a strong password"
 msgstr "<0>Click to change password.</0> Secure your account with a strong password"
 
-#: src/components/pages/AddModelPage.tsx:56
-msgid "A model consist of both fields and templates. A field is used in a note to fill values that are used inside the template, and the template is used to define the frontside and backside of each flashcard, using the fields defined in the model. You'll be able to edit the templates content after creating the model."
-msgstr "A model consist of both fields and templates. A field is used in a note to fill values that are used inside the template, and the template is used to define the frontside and backside of each flashcard, using the fields defined in the model. You'll be able to edit the templates content after creating the model."
+#: src/components/ModelFieldsForm.tsx:40
+msgid "A model consist of both fields and templates. A field is used in a note to fill values that are used inside the template."
+msgstr "A model consist of both fields and templates. A field is used in a note to fill values that are used inside the template."
 
 #: src/components/pages/HomePage.tsx:62
 msgid "A new update is available!"
@@ -58,16 +58,16 @@ msgstr "About us"
 msgid "Account Settings"
 msgstr "Account Settings"
 
-#: src/components/forms/RegisterForm.tsx:105
+#: src/components/forms/RegisterForm.tsx:108
 msgid "Account created successfully"
 msgstr "Account created successfully"
 
-#: src/components/NotesTable.tsx:29
-#: src/components/pages/AddNotePage.tsx:165
+#: src/components/NotesTable.tsx:31
+#: src/components/pages/AddNotePage.tsx:168
 msgid "Add Note"
 msgstr "Add Note"
 
-#: src/components/pages/AddModelPage.tsx:175
+#: src/components/ModelFieldsForm.tsx:35
 msgid "Add field"
 msgstr "Add field"
 
@@ -76,11 +76,11 @@ msgstr "Add field"
 msgid "Add new"
 msgstr "Add new"
 
-#: src/components/pages/AddModelPage.tsx:139
+#: src/components/ModelTemplatesForm.tsx:37
 msgid "Add template"
 msgstr "Add template"
 
-#: src/components/forms/RegisterForm.tsx:48
+#: src/components/forms/RegisterForm.tsx:50
 msgid "Agreement is required"
 msgstr "Agreement is required"
 
@@ -101,7 +101,11 @@ msgstr "Align right"
 msgid "Already have an account? <0>Log In</0>"
 msgstr "Already have an account? <0>Log In</0>"
 
-#: src/components/pages/NotePage.tsx:133
+#: src/components/ModelTemplatesForm.tsx:87
+msgid "An error has occurred when creating your model. Submit the form to try again"
+msgstr "An error has occurred when creating your model. Submit the form to try again"
+
+#: src/components/pages/NotePage.tsx:136
 msgid "An error has occurred when saving your note"
 msgstr "An error has occurred when saving your note"
 
@@ -109,7 +113,7 @@ msgstr "An error has occurred when saving your note"
 msgid "An error has occurred when trying to get your decks to study."
 msgstr "An error has occurred when trying to get your decks to study."
 
-#: src/components/pages/StatisticsPage.tsx:158
+#: src/components/pages/StatisticsPage.tsx:160
 msgid "An error has occurred, try refreshing the page or wait a few minutes before trying again"
 msgstr "An error has occurred, try refreshing the page or wait a few minutes before trying again"
 
@@ -129,7 +133,7 @@ msgstr "An error occurred when deleting the model"
 msgid "An error occurred when saving the template"
 msgstr "An error occurred when saving the template"
 
-#: src/components/GeneralSettings.tsx:93
+#: src/components/GeneralSettings.tsx:92
 #: src/components/UpdatePasswordDialog.tsx:68
 #: src/components/UpdatePasswordDialog.tsx:73
 msgid "An unexpected error has occurred"
@@ -137,8 +141,8 @@ msgstr "An unexpected error has occurred"
 
 #: src/components/ProfileSettings.tsx:73
 #: src/components/ProfileSettings.tsx:78
-#: src/components/forms/RegisterForm.tsx:90
-#: src/components/forms/RegisterForm.tsx:95
+#: src/components/forms/RegisterForm.tsx:93
+#: src/components/forms/RegisterForm.tsx:98
 msgid "An unknown error has occurred"
 msgstr "An unknown error has occurred"
 
@@ -166,13 +170,17 @@ msgstr "Are you sure you want to delete this model? {0, plural, one {There's # n
 msgid "Are you sure you want to delete this note? {0, plural, one {It contains one flashcard} other {It contains # flashcards}}"
 msgstr "Are you sure you want to delete this note? {0, plural, one {It contains one flashcard} other {It contains # flashcards}}"
 
-#: src/components/FlashCardRenderer.tsx:68
+#: src/components/FlashCardRenderer.tsx:70
 msgid "Back side"
 msgstr "Back side"
 
-#: src/components/FlashCardRenderer.tsx:68
+#: src/components/FlashCardRenderer.tsx:70
 msgid "Back side template is empty"
 msgstr "Back side template is empty"
+
+#: src/components/pages/AddModelPage.tsx:189
+msgid "Base information"
+msgstr "Base information"
 
 #: src/components/editor/BlockStyleControls.tsx:21
 msgid "Blockquote"
@@ -201,7 +209,7 @@ msgstr "Change password"
 msgid "Change your account username"
 msgstr "Change your account username"
 
-#: src/components/pages/ForgotPasswordPage.tsx:91
+#: src/components/pages/ForgotPasswordPage.tsx:90
 msgid "Check your inbox!"
 msgstr "Check your inbox!"
 
@@ -251,17 +259,21 @@ msgstr "Continue Studying"
 msgid "Create"
 msgstr "Create"
 
-#: src/components/pages/AddNotePage.tsx:190
+#: src/components/pages/AddNotePage.tsx:195
 msgid "Create a model"
 msgstr "Create a model"
+
+#: src/components/ModelNameForm.tsx:19
+msgid "Create a name for your model."
+msgstr "Create a name for your model."
 
 #: src/components/pages/DecksSection.tsx:44
 #: src/components/pages/DecksSection.tsx:60
 msgid "Create deck"
 msgstr "Create deck"
 
-#: src/components/pages/AddModelPage.tsx:52
-#: src/components/pages/AddModelPage.tsx:184
+#: src/components/ModelTemplatesForm.tsx:82
+#: src/components/pages/AddModelPage.tsx:183
 #: src/components/pages/ModelsSection.tsx:43
 #: src/components/pages/ModelsSection.tsx:57
 msgid "Create model"
@@ -271,7 +283,7 @@ msgstr "Create model"
 msgid "Create new deck"
 msgstr "Create new deck"
 
-#: src/components/pages/AddNotePage.tsx:131
+#: src/components/pages/AddNotePage.tsx:132
 msgid "Create note for deck <0>{0}</0>"
 msgstr "Create note for deck <0>{0}</0>"
 
@@ -283,7 +295,7 @@ msgstr "Create template"
 msgid "Create your account today and start studying for free!"
 msgstr "Create your account today and start studying for free!"
 
-#: src/components/pages/AddModelPage.tsx:184
+#: src/components/ModelTemplatesForm.tsx:82
 msgid "Creating model..."
 msgstr "Creating model..."
 
@@ -295,13 +307,13 @@ msgstr "Current password"
 msgid "Current password is required to change your password"
 msgstr "Current password is required to change your password"
 
-#: src/components/Shell.tsx:51
+#: src/components/Shell.tsx:52
 msgid "Dark mode"
 msgstr "Dark mode"
 
-#: src/components/pages/StatisticsPage.tsx:154
-#: src/components/pages/StatisticsPage.tsx:170
-#: src/components/pages/StatisticsPage.tsx:220
+#: src/components/pages/StatisticsPage.tsx:156
+#: src/components/pages/StatisticsPage.tsx:172
+#: src/components/pages/StatisticsPage.tsx:222
 msgid "Deck Statistics"
 msgstr "Deck Statistics"
 
@@ -321,7 +333,7 @@ msgstr "Deck details"
 msgid "Deck not found"
 msgstr "Deck not found"
 
-#: src/components/pages/NotePage.tsx:166
+#: src/components/pages/NotePage.tsx:169
 msgid "Deck {0}"
 msgstr "Deck {0}"
 
@@ -334,7 +346,7 @@ msgstr "Decks"
 #: src/components/DeleteModelButton.tsx:71
 #: src/components/DeleteModelButton.tsx:91
 #: src/components/DeleteNoteDialog.tsx:53
-#: src/components/NotesTable.tsx:77
+#: src/components/NotesTable.tsx:79
 msgid "Delete"
 msgstr "Delete"
 
@@ -378,40 +390,40 @@ msgstr "Don't have an account? <0>Sign Up</0>"
 msgid "Easy"
 msgstr "Easy"
 
-#: src/components/NotesTable.tsx:74
+#: src/components/NotesTable.tsx:76
 msgid "Edit"
 msgstr "Edit"
 
-#: src/components/pages/ModelPage.tsx:151
-#: src/components/pages/ModelPage.tsx:163
+#: src/components/pages/ModelPage.tsx:153
+#: src/components/pages/ModelPage.tsx:165
 msgid "Edit fields"
 msgstr "Edit fields"
 
-#: src/components/pages/ModelPage.tsx:148
-#: src/components/pages/ModelPage.tsx:159
+#: src/components/pages/ModelPage.tsx:150
+#: src/components/pages/ModelPage.tsx:161
 msgid "Edit templates"
 msgstr "Edit templates"
 
 #: src/components/ProfileSettings.tsx:95
-#: src/components/forms/RegisterForm.tsx:114
+#: src/components/forms/RegisterForm.tsx:117
 msgid "Email"
 msgstr "Email"
 
-#: src/components/pages/ForgotPasswordPage.tsx:121
+#: src/components/pages/ForgotPasswordPage.tsx:120
 msgid "Email address"
 msgstr "Email address"
 
 #: src/components/ProfileSettings.tsx:64
-#: src/components/forms/RegisterForm.tsx:46
+#: src/components/forms/RegisterForm.tsx:48
 msgid "Email is required"
 msgstr "Email is required"
 
 #: src/components/ProfileSettings.tsx:63
-#: src/components/forms/RegisterForm.tsx:72
+#: src/components/forms/RegisterForm.tsx:75
 msgid "Email must be a valid email"
 msgstr "Email must be a valid email"
 
-#: src/components/pages/ForgotPasswordPage.tsx:58
+#: src/components/pages/ForgotPasswordPage.tsx:59
 msgid "Email sent!"
 msgstr "Email sent!"
 
@@ -427,34 +439,35 @@ msgstr "End study session"
 msgid "English"
 msgstr "English"
 
-#: src/components/pages/ForgotPasswordPage.tsx:114
+#: src/components/pages/ForgotPasswordPage.tsx:113
 msgid "Enter the email associated with your account and we will send a link to reset your password"
 msgstr "Enter the email associated with your account and we will send a link to reset your password"
 
-#: src/components/pages/ForgotPasswordPage.tsx:128
+#: src/components/pages/ForgotPasswordPage.tsx:127
 msgid "Enter your email address"
 msgstr "Enter your email address"
 
-#: src/components/pages/AddModelPage.tsx:156
-msgid "Field #{index}"
-msgstr "Field #{index}"
+#: src/components/views/Alert.tsx:30
+msgid "Error"
+msgstr "Error"
 
 #: src/components/EditFieldsDialog.tsx:152
-#: src/components/pages/AddModelPage.tsx:161
+#: src/components/ModelFieldsForm.tsx:57
 msgid "Field name"
 msgstr "Field name"
 
-#: src/components/pages/AddModelPage.tsx:76
+#: src/components/ModelFieldsForm.tsx:18
 msgid "Field name is required"
 msgstr "Field name is required"
 
-#: src/components/FieldValueEditor.tsx:18
+#: src/components/FieldValueEditor.tsx:19
 msgid "Field value..."
 msgstr "Field value..."
 
 #: src/components/EditFieldsDialog.tsx:138
-#: src/components/pages/AddModelPage.tsx:151
-#: src/components/pages/AddNotePage.tsx:152
+#: src/components/ModelFieldsForm.tsx:32
+#: src/components/pages/AddModelPage.tsx:192
+#: src/components/pages/AddNotePage.tsx:155
 msgid "Fields"
 msgstr "Fields"
 
@@ -466,12 +479,12 @@ msgstr "Fields that you can use in your templates and notes. You can add a field
 msgid "First page"
 msgstr "First page"
 
-#: src/components/NotesTable.tsx:45
-#: src/components/pages/NotePage.tsx:183
+#: src/components/NotesTable.tsx:47
+#: src/components/pages/NotePage.tsx:186
 msgid "Flashcards"
 msgstr "Flashcards"
 
-#: src/components/pages/StatisticsPage.tsx:294
+#: src/components/pages/StatisticsPage.tsx:300
 msgid "Flashcards studied"
 msgstr "Flashcards studied"
 
@@ -479,11 +492,11 @@ msgstr "Flashcards studied"
 msgid "For security, please enter your current password to continue."
 msgstr "For security, please enter your current password to continue."
 
-#: src/components/pages/ForgotPasswordPage.tsx:141
+#: src/components/pages/ForgotPasswordPage.tsx:140
 msgid "Forgot password"
 msgstr "Forgot password"
 
-#: src/components/pages/ForgotPasswordPage.tsx:110
+#: src/components/pages/ForgotPasswordPage.tsx:109
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
@@ -491,11 +504,11 @@ msgstr "Forgot password?"
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
-#: src/components/FlashCardRenderer.tsx:65
+#: src/components/FlashCardRenderer.tsx:67
 msgid "Front side"
 msgstr "Front side"
 
-#: src/components/FlashCardRenderer.tsx:65
+#: src/components/FlashCardRenderer.tsx:67
 msgid "Front side template is empty"
 msgstr "Front side template is empty"
 
@@ -508,14 +521,22 @@ msgstr "Go back"
 msgid "Go to Home"
 msgstr "Go to Home"
 
+#: src/components/ModelNameForm.tsx:25
+msgid "Go to fields"
+msgstr "Go to fields"
+
 #: src/components/pages/DeckPage.tsx:143
 #: src/components/pages/ModelPage.tsx:100
 msgid "Go to home"
 msgstr "Go to home"
 
-#: src/components/pages/ForgotPasswordPage.tsx:103
+#: src/components/pages/ForgotPasswordPage.tsx:102
 msgid "Go to login"
 msgstr "Go to login"
+
+#: src/components/ModelFieldsForm.tsx:70
+msgid "Go to templates"
+msgstr "Go to templates"
 
 #: src/components/pages/StudyPage.tsx:217
 msgid "Good"
@@ -553,15 +574,15 @@ msgstr "Hard"
 msgid "Home"
 msgstr "Home"
 
-#: src/components/forms/RegisterForm.tsx:118
+#: src/components/forms/RegisterForm.tsx:121
 msgid "I agree to the <0>Terms & Conditions</0>"
 msgstr "I agree to the <0>Terms & Conditions</0>"
 
-#: src/components/pages/StatisticsPage.tsx:271
+#: src/components/pages/StatisticsPage.tsx:277
 msgid "Interval"
 msgstr "Interval"
 
-#: src/components/pages/ForgotPasswordPage.tsx:130
+#: src/components/pages/ForgotPasswordPage.tsx:129
 msgid "Invalid email"
 msgstr "Invalid email"
 
@@ -582,11 +603,11 @@ msgstr "Italic"
 msgid "Items per page"
 msgstr "Items per page"
 
-#: src/components/GeneralSettings.tsx:107
+#: src/components/GeneralSettings.tsx:106
 msgid "Language"
 msgstr "Language"
 
-#: src/components/Pagination.tsx:66
+#: src/components/Pagination.tsx:68
 msgid "Last page"
 msgstr "Last page"
 
@@ -594,7 +615,7 @@ msgstr "Last page"
 msgid "Learning"
 msgstr "Learning"
 
-#: src/components/Shell.tsx:56
+#: src/components/Shell.tsx:57
 msgid "Log out"
 msgstr "Log out"
 
@@ -616,7 +637,7 @@ msgstr "Make sure your knowledge will last"
 msgid "Marketplace"
 msgstr "Marketplace"
 
-#: src/components/pages/AddModelPage.tsx:95
+#: src/components/pages/AddModelPage.tsx:125
 msgid "Model created successfully"
 msgstr "Model created successfully"
 
@@ -628,7 +649,7 @@ msgstr "Model deleted successfully"
 msgid "Model details"
 msgstr "Model details"
 
-#: src/components/pages/AddModelPage.tsx:107
+#: src/components/ModelNameForm.tsx:22
 msgid "Model name"
 msgstr "Model name"
 
@@ -636,7 +657,7 @@ msgstr "Model name"
 msgid "Model not found"
 msgstr "Model not found"
 
-#: src/components/NotesTable.tsx:42
+#: src/components/NotesTable.tsx:44
 msgid "Model type"
 msgstr "Model type"
 
@@ -648,7 +669,7 @@ msgstr "Models"
 msgid "Monospace"
 msgstr "Monospace"
 
-#: src/components/pages/AddModelPage.tsx:74
+#: src/components/ModelNameForm.tsx:13
 msgid "Name is required"
 msgstr "Name is required"
 
@@ -678,47 +699,39 @@ msgstr "New password must be at lest 6 characters"
 msgid "New template name"
 msgstr "New template name"
 
-#: src/components/Pagination.tsx:63
+#: src/components/Pagination.tsx:65
 msgid "Next page"
 msgstr "Next page"
 
-#: src/components/pages/AddModelPage.tsx:171
-msgid "No fields added"
-msgstr "No fields added"
-
-#: src/components/NotesTable.tsx:57
+#: src/components/NotesTable.tsx:59
 msgid "No notes were found"
 msgstr "No notes were found"
 
-#: src/components/pages/AddModelPage.tsx:135
-msgid "No templates added"
-msgstr "No templates added"
-
-#: src/components/NotesTable.tsx:39
+#: src/components/NotesTable.tsx:41
 msgid "Note"
 msgstr "Note"
 
-#: src/components/pages/AddNotePage.tsx:104
+#: src/components/pages/AddNotePage.tsx:105
 msgid "Note created successfully"
 msgstr "Note created successfully"
 
-#: src/components/pages/NotePage.tsx:169
+#: src/components/pages/NotePage.tsx:172
 msgid "Note details"
 msgstr "Note details"
 
-#: src/components/pages/AddNotePage.tsx:139
+#: src/components/pages/AddNotePage.tsx:142
 msgid "Note's model"
 msgstr "Note's model"
 
-#: src/components/pages/DeckPage.tsx:176
+#: src/components/pages/DeckPage.tsx:178
 msgid "Notes"
 msgstr "Notes"
 
-#: src/components/pages/StatisticsPage.tsx:261
+#: src/components/pages/StatisticsPage.tsx:267
 msgid "Number of flashcards studied"
 msgstr "Number of flashcards studied"
 
-#: src/components/pages/StatisticsPage.tsx:260
+#: src/components/pages/StatisticsPage.tsx:266
 msgid "Number of times studied"
 msgstr "Number of times studied"
 
@@ -730,13 +743,13 @@ msgstr "OL"
 msgid "Optimize your knowledge retention with this effective study method."
 msgstr "Optimize your knowledge retention with this effective study method."
 
-#: src/components/pages/StatisticsPage.tsx:234
+#: src/components/pages/StatisticsPage.tsx:240
 msgid "Overview"
 msgstr "Overview"
 
 #: src/components/ProfileSettings.tsx:98
 #: src/components/forms/LoginForm.tsx:69
-#: src/components/forms/RegisterForm.tsx:115
+#: src/components/forms/RegisterForm.tsx:118
 msgid "Password"
 msgstr "Password"
 
@@ -746,11 +759,11 @@ msgid "Password changed successfully"
 msgstr "Password changed successfully"
 
 #: src/components/forms/LoginForm.tsx:22
-#: src/components/forms/RegisterForm.tsx:47
+#: src/components/forms/RegisterForm.tsx:49
 msgid "Password is required"
 msgstr "Password is required"
 
-#: src/components/forms/RegisterForm.tsx:76
+#: src/components/forms/RegisterForm.tsx:79
 #: src/components/pages/ResetPasswordPage.tsx:130
 msgid "Password must be at least 6 characters"
 msgstr "Password must be at least 6 characters"
@@ -763,15 +776,15 @@ msgstr "Please, try reloading the page"
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: src/components/GeneralSettings.tsx:105
+#: src/components/GeneralSettings.tsx:104
 msgid "Preferences"
 msgstr "Preferences"
 
-#: src/components/GeneralSettings.tsx:96
+#: src/components/GeneralSettings.tsx:95
 msgid "Preferences updated successfully"
 msgstr "Preferences updated successfully"
 
-#: src/components/pages/NotePage.tsx:214
+#: src/components/pages/NotePage.tsx:218
 msgid "Preview"
 msgstr "Preview"
 
@@ -800,17 +813,17 @@ msgstr "Ready to work offline"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: src/components/forms/RegisterForm.tsx:49
-#: src/components/forms/RegisterForm.tsx:127
+#: src/components/forms/RegisterForm.tsx:51
+#: src/components/forms/RegisterForm.tsx:130
 #: src/components/pages/RegisterPage.tsx:12
 msgid "Register"
 msgstr "Register"
 
-#: src/components/pages/AddModelPage.tsx:164
+#: src/components/ModelFieldsForm.tsx:60
 msgid "Remove field"
 msgstr "Remove field"
 
-#: src/components/pages/AddModelPage.tsx:128
+#: src/components/ModelTemplatesForm.tsx:72
 msgid "Remove template"
 msgstr "Remove template"
 
@@ -830,7 +843,7 @@ msgstr "Rename {0} template"
 msgid "Repeat"
 msgstr "Repeat"
 
-#: src/components/pages/ForgotPasswordPage.tsx:135
+#: src/components/pages/ForgotPasswordPage.tsx:134
 msgid "Request Password Reset"
 msgstr "Request Password Reset"
 
@@ -855,7 +868,7 @@ msgstr "Retry"
 msgid "Review"
 msgstr "Review"
 
-#: src/components/GeneralSettings.tsx:148
+#: src/components/GeneralSettings.tsx:147
 msgid "Save preferences"
 msgstr "Save preferences"
 
@@ -867,19 +880,19 @@ msgstr "Save profile"
 msgid "Saved successfully"
 msgstr "Saved successfully"
 
-#: src/components/NotesTable.tsx:32
+#: src/components/NotesTable.tsx:34
 msgid "Search notes..."
 msgstr "Search notes..."
 
-#: src/components/pages/AddNotePage.tsx:142
+#: src/components/pages/AddNotePage.tsx:145
 msgid "Select a model"
 msgstr "Select a model"
 
-#: src/components/pages/StatisticsPage.tsx:224
+#: src/components/pages/StatisticsPage.tsx:228
 msgid "Select your deck"
 msgstr "Select your deck"
 
-#: src/components/Shell.tsx:46
+#: src/components/Shell.tsx:47
 #: src/components/pages/SettingsPage.tsx:10
 msgid "Settings"
 msgstr "Settings"
@@ -908,10 +921,14 @@ msgstr "Something went wrong"
 msgid "Start Session"
 msgstr "Start Session"
 
-#: src/components/Shell.tsx:74
+#: src/components/Shell.tsx:79
 #: src/components/pages/HomePage.tsx:104
 msgid "Statistics"
 msgstr "Statistics"
+
+#: src/components/StepTab.tsx:26
+msgid "Step {0}"
+msgstr "Step {0}"
 
 #: src/components/pages/HomePage.tsx:140
 msgid "Study"
@@ -921,7 +938,7 @@ msgstr "Study"
 msgid "Study deck"
 msgstr "Study deck"
 
-#: src/components/pages/StatisticsPage.tsx:267
+#: src/components/pages/StatisticsPage.tsx:273
 msgid "Study frequency"
 msgstr "Study frequency"
 
@@ -929,9 +946,9 @@ msgstr "Study frequency"
 msgid "Study today"
 msgstr "Study today"
 
-#: src/components/pages/AddModelPage.tsx:120
-msgid "Template #{index}"
-msgstr "Template #{index}"
+#: src/components/views/Alert.tsx:27
+msgid "Success"
+msgstr "Success"
 
 #: src/components/pages/ModelPage.tsx:79
 msgid "Template back side"
@@ -942,17 +959,18 @@ msgid "Template front side"
 msgstr "Template front side"
 
 #: src/components/EditTemplatesDialog.tsx:173
-#: src/components/pages/AddModelPage.tsx:125
+#: src/components/ModelTemplatesForm.tsx:69
 msgid "Template name"
 msgstr "Template name"
 
-#: src/components/pages/AddModelPage.tsx:79
+#: src/components/ModelTemplatesForm.tsx:19
 msgid "Template name is required"
 msgstr "Template name is required"
 
 #: src/components/EditTemplatesDialog.tsx:162
-#: src/components/pages/AddModelPage.tsx:115
-#: src/components/pages/ModelPage.tsx:135
+#: src/components/ModelTemplatesForm.tsx:33
+#: src/components/pages/AddModelPage.tsx:195
+#: src/components/pages/ModelPage.tsx:137
 msgid "Templates"
 msgstr "Templates"
 
@@ -964,9 +982,13 @@ msgstr "Templates of the current model"
 msgid "Terms and Conditions"
 msgstr "Terms and Conditions"
 
-#: src/components/pages/AddNotePage.tsx:168
+#: src/components/pages/AddNotePage.tsx:171
 msgid "The selected model doesn't have any fields. <0>Click here to edit it</0>"
 msgstr "The selected model doesn't have any fields. <0>Click here to edit it</0>"
+
+#: src/components/ModelTemplatesForm.tsx:42
+msgid "The templates are used to define the frontside and backside of each flashcard, using the fields defined in the previous step. You'll be able to edit the template's content after creating the model."
+msgstr "The templates are used to define the frontside and backside of each flashcard, using the fields defined in the previous step. You'll be able to edit the template's content after creating the model."
 
 #: src/components/forms/AddDeckForm.tsx:37
 msgid "The title is required"
@@ -984,7 +1006,7 @@ msgstr "This action will delete all values from the notes associated with this m
 msgid "This link may be broken or the typed URL is incorrect."
 msgstr "This link may be broken or the typed URL is incorrect."
 
-#: src/components/GeneralSettings.tsx:122
+#: src/components/GeneralSettings.tsx:121
 msgid "Time zone"
 msgstr "Time zone"
 
@@ -992,11 +1014,11 @@ msgstr "Time zone"
 msgid "Title"
 msgstr "Title"
 
-#: src/components/pages/AddNotePage.tsx:182
+#: src/components/pages/AddNotePage.tsx:187
 msgid "To create a note you need to associate it with a model."
 msgstr "To create a note you need to associate it with a model."
 
-#: src/components/pages/StatisticsPage.tsx:238
+#: src/components/pages/StatisticsPage.tsx:244
 msgid "Total study time"
 msgstr "Total study time"
 
@@ -1005,11 +1027,11 @@ msgstr "Total study time"
 msgid "Try again"
 msgstr "Try again"
 
-#: src/components/pages/StatisticsPage.tsx:177
+#: src/components/pages/StatisticsPage.tsx:179
 msgid "Try creating a deck first and study it in order to see your study statistics here."
 msgstr "Try creating a deck first and study it in order to see your study statistics here."
 
-#: src/components/pages/StatisticsPage.tsx:324
+#: src/components/pages/StatisticsPage.tsx:330
 msgid "Try selecting a broader interval above."
 msgstr "Try selecting a broader interval above."
 
@@ -1029,53 +1051,54 @@ msgstr "Update account password"
 msgid "Update your account email"
 msgstr "Update your account email"
 
-#: src/components/GeneralSettings.tsx:107
+#: src/components/GeneralSettings.tsx:106
 msgid "Update your preferred language for headlines, buttons and other texts."
 msgstr "Update your preferred language for headlines, buttons and other texts."
 
-#: src/components/GeneralSettings.tsx:122
+#: src/components/GeneralSettings.tsx:121
 msgid "Used to compute the statistics and study schedule in your local time."
 msgstr "Used to compute the statistics and study schedule in your local time."
 
-#: src/components/pages/ForgotPasswordPage.tsx:62
+#: src/components/pages/ForgotPasswordPage.tsx:63
 msgid "User not found"
 msgstr "User not found"
 
 #: src/components/ProfileSettings.tsx:92
 #: src/components/forms/LoginForm.tsx:68
-#: src/components/forms/RegisterForm.tsx:113
+#: src/components/forms/RegisterForm.tsx:116
 msgid "Username"
 msgstr "Username"
 
 #: src/components/ProfileSettings.tsx:60
 #: src/components/forms/LoginForm.tsx:21
-#: src/components/forms/RegisterForm.tsx:45
+#: src/components/forms/RegisterForm.tsx:47
 msgid "Username is required"
 msgstr "Username is required"
 
 #: src/components/ProfileSettings.tsx:57
-#: src/components/forms/RegisterForm.tsx:66
+#: src/components/forms/RegisterForm.tsx:69
 msgid "Username must be at least 4 characters"
 msgstr "Username must be at least 4 characters"
 
 #: src/components/ProfileSettings.tsx:58
-#: src/components/forms/RegisterForm.tsx:67
+#: src/components/forms/RegisterForm.tsx:70
 msgid "Username must be at most 20 characters"
 msgstr "Username must be at most 20 characters"
 
 #: src/components/ProfileSettings.tsx:59
-#: src/components/forms/RegisterForm.tsx:68
+#: src/components/forms/RegisterForm.tsx:71
 msgid "Username must consist only of alphanumeric characters and underscores"
 msgstr "Username must consist only of alphanumeric characters and underscores"
 
 #: src/components/forms/AddDeckForm.tsx:76
-#: src/components/pages/AddModelPage.tsx:97
-#: src/components/pages/AddNotePage.tsx:106
+#: src/components/pages/AddModelPage.tsx:127
+#: src/components/pages/AddNotePage.tsx:107
 msgid "View"
 msgstr "View"
 
 #: src/components/EditFieldsDialog.tsx:164
 #: src/components/EditTemplatesDialog.tsx:184
+#: src/components/views/Alert.tsx:30
 msgid "Warning"
 msgstr "Warning"
 
@@ -1083,23 +1106,23 @@ msgstr "Warning"
 msgid "We couldn't find the page you requested"
 msgstr "We couldn't find the page you requested"
 
-#: src/components/pages/StatisticsPage.tsx:174
+#: src/components/pages/StatisticsPage.tsx:176
 msgid "We don't have anything to show to you right now."
 msgstr "We don't have anything to show to you right now."
 
-#: src/components/pages/StatisticsPage.tsx:319
+#: src/components/pages/StatisticsPage.tsx:325
 msgid "We don't have enough data to display in the supplied period."
 msgstr "We don't have enough data to display in the supplied period."
 
-#: src/components/pages/ForgotPasswordPage.tsx:96
+#: src/components/pages/ForgotPasswordPage.tsx:95
 msgid "We have sent you an email with instructions to help you reset your password. Remember to also check the spam folder."
 msgstr "We have sent you an email with instructions to help you reset your password. Remember to also check the spam folder."
 
-#: src/components/pages/AddModelPage.tsx:66
+#: src/components/ModelTemplatesForm.tsx:51
 msgid "When you create a note, we will create the corresponding number of flashcards based on how much templates the note's model has, and will use the note's values to fill in the template."
 msgstr "When you create a note, we will create the corresponding number of flashcards based on how much templates the note's model has, and will use the note's values to fill in the template."
 
-#: src/components/pages/AddNotePage.tsx:178
+#: src/components/pages/AddNotePage.tsx:183
 msgid "You haven't created a model yet."
 msgstr "You haven't created a model yet."
 
@@ -1111,11 +1134,11 @@ msgstr "You haven't created any decks yet."
 msgid "You haven't created any models yet"
 msgstr "You haven't created any models yet"
 
-#: src/components/NotesTable.tsx:53
+#: src/components/NotesTable.tsx:55
 msgid "You haven't created any notes on this deck yet"
 msgstr "You haven't created any notes on this deck yet"
 
-#: src/components/pages/ModelPage.tsx:181
+#: src/components/pages/ModelPage.tsx:183
 msgid "You haven't created any templates on this model yet."
 msgstr "You haven't created any templates on this model yet."
 
@@ -1135,12 +1158,12 @@ msgstr "Your model is not saved, are you sure you want to exit the page?"
 msgid "Your models"
 msgstr "Your models"
 
-#: src/components/pages/NotePage.tsx:133
+#: src/components/pages/NotePage.tsx:136
 msgid "Your note is not saved, are you sure you want to exit the page?"
 msgstr "Your note is not saved, are you sure you want to exit the page?"
 
-#: src/components/NotesTable.tsx:63
-#: src/components/pages/NotePage.tsx:173
+#: src/components/NotesTable.tsx:65
+#: src/components/pages/NotePage.tsx:176
 msgid "empty note"
 msgstr "empty note"
 
@@ -1157,14 +1180,14 @@ msgid "{0, plural, one {# field} other {# fields}}"
 msgstr "{0, plural, one {# field} other {# fields}}"
 
 #: src/components/DeckCard.tsx:64
-#: src/components/pages/DeckPage.tsx:168
-#: src/components/pages/ModelPage.tsx:125
+#: src/components/pages/DeckPage.tsx:170
+#: src/components/pages/ModelPage.tsx:127
 msgid "{0, plural, one {# flashcard} other {# flashcards}}"
 msgstr "{0, plural, one {# flashcard} other {# flashcards}}"
 
 #: src/components/DeckCard.tsx:59
-#: src/components/pages/DeckPage.tsx:166
-#: src/components/pages/ModelPage.tsx:120
+#: src/components/pages/DeckPage.tsx:168
+#: src/components/pages/ModelPage.tsx:122
 msgid "{0, plural, one {# note} other {# notes}}"
 msgstr "{0, plural, one {# note} other {# notes}}"
 
@@ -1180,7 +1203,7 @@ msgstr "{0, plural, zero {# decks} one {# deck} other {# decks}}"
 msgid "{0, plural, zero {# models} one {# model} other {# models}}"
 msgstr "{0, plural, zero {# models} one {# model} other {# models}}"
 
-#: src/components/pages/StatisticsPage.tsx:238
+#: src/components/pages/StatisticsPage.tsx:244
 msgid "{0, select, millisecond {{1, plural, one {{formattedStudyTime} millisecond} other {{formattedStudyTime} milliseconds}}} second {{2, plural, one {{formattedStudyTime} second} other {{formattedStudyTime} seconds}}} minute {{3, plural, one {{formattedStudyTime} minute} other {{formattedStudyTime} minutes}}} hour {{4, plural, one {{formattedStudyTime} hour} other {{formattedStudyTime} hours}}} day {{5, plural, one {{formattedStudyTime} day} other {{formattedStudyTime} days}}}}"
 msgstr "{0, select, millisecond {{1, plural, one {{formattedStudyTime} millisecond} other {{formattedStudyTime} milliseconds}}} second {{2, plural, one {{formattedStudyTime} second} other {{formattedStudyTime} seconds}}} minute {{3, plural, one {{formattedStudyTime} minute} other {{formattedStudyTime} minutes}}} hour {{4, plural, one {{formattedStudyTime} hour} other {{formattedStudyTime} hours}}} day {{5, plural, one {{formattedStudyTime} day} other {{formattedStudyTime} days}}}}"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/pages/DeckPage.tsx:178
+#: src/components/pages/DeckPage.tsx:180
 msgid "({0} notes)"
 msgstr "({0} notas)"
 
-#: src/components/pages/StatisticsPage.tsx:277
+#: src/components/pages/StatisticsPage.tsx:283
 msgid "1 month"
 msgstr "1 mês"
 
-#: src/components/pages/StatisticsPage.tsx:280
+#: src/components/pages/StatisticsPage.tsx:286
 msgid "1 year"
 msgstr "1 ano"
 
-#: src/components/pages/StatisticsPage.tsx:274
+#: src/components/pages/StatisticsPage.tsx:280
 msgid "7 days"
 msgstr "7 dias"
 
@@ -33,9 +33,9 @@ msgstr "7 dias"
 msgid "<0>Click to change password.</0> Secure your account with a strong password"
 msgstr "<0>Clique para mudar a senha.</0> Proteja sua conta com uma senha forte"
 
-#: src/components/pages/AddModelPage.tsx:56
-msgid "A model consist of both fields and templates. A field is used in a note to fill values that are used inside the template, and the template is used to define the frontside and backside of each flashcard, using the fields defined in the model. You'll be able to edit the templates content after creating the model."
-msgstr "Um modelo consiste tanto de campos como templates. Um campo é utilizado em uma nota para preencher os valores que são utilizados no template, e o template é utilizado para definir a frente e o verso de cada flashcard, utilizando os campos definidos no modelo. Você poderá editar o conteúdo dos templates após criar o modelo."
+#: src/components/ModelFieldsForm.tsx:40
+msgid "A model consist of both fields and templates. A field is used in a note to fill values that are used inside the template."
+msgstr "Um modelo consiste tanto de campos quanto templates. Um campo é utilizado em uma nota para preencher os valores usados dentro do template."
 
 #: src/components/pages/HomePage.tsx:62
 msgid "A new update is available!"
@@ -58,16 +58,16 @@ msgstr "Sobre nós"
 msgid "Account Settings"
 msgstr "Configurações da conta"
 
-#: src/components/forms/RegisterForm.tsx:105
+#: src/components/forms/RegisterForm.tsx:108
 msgid "Account created successfully"
 msgstr "Conta criada com sucesso"
 
-#: src/components/NotesTable.tsx:29
-#: src/components/pages/AddNotePage.tsx:165
+#: src/components/NotesTable.tsx:31
+#: src/components/pages/AddNotePage.tsx:168
 msgid "Add Note"
 msgstr "Adicionar Nota"
 
-#: src/components/pages/AddModelPage.tsx:175
+#: src/components/ModelFieldsForm.tsx:35
 msgid "Add field"
 msgstr "Adicionar campo"
 
@@ -76,11 +76,11 @@ msgstr "Adicionar campo"
 msgid "Add new"
 msgstr "Adicionar novo"
 
-#: src/components/pages/AddModelPage.tsx:139
+#: src/components/ModelTemplatesForm.tsx:37
 msgid "Add template"
 msgstr "Adicionar template"
 
-#: src/components/forms/RegisterForm.tsx:48
+#: src/components/forms/RegisterForm.tsx:50
 msgid "Agreement is required"
 msgstr "Concordância é obrigatória"
 
@@ -101,7 +101,11 @@ msgstr "Alinhar à direita"
 msgid "Already have an account? <0>Log In</0>"
 msgstr "Já possui uma conta? <0>Entrar</0>"
 
-#: src/components/pages/NotePage.tsx:133
+#: src/components/ModelTemplatesForm.tsx:87
+msgid "An error has occurred when creating your model. Submit the form to try again"
+msgstr "Um erro ocorreu ao criar o seu modelo. Submeta o formulário para tentar novamente"
+
+#: src/components/pages/NotePage.tsx:136
 msgid "An error has occurred when saving your note"
 msgstr "Ocorreu um erro ao salvar sua nota"
 
@@ -109,7 +113,7 @@ msgstr "Ocorreu um erro ao salvar sua nota"
 msgid "An error has occurred when trying to get your decks to study."
 msgstr "Ocorreu um erro enquanto tentávamos buscar seus decks para estudar."
 
-#: src/components/pages/StatisticsPage.tsx:158
+#: src/components/pages/StatisticsPage.tsx:160
 msgid "An error has occurred, try refreshing the page or wait a few minutes before trying again"
 msgstr "Ocorreu um erro, tente recarregar a página ou espere alguns minutos antes de tentar novamente"
 
@@ -129,7 +133,7 @@ msgstr "Ocorreu um erro ao apagar o modelo"
 msgid "An error occurred when saving the template"
 msgstr "Ocorreu um erro ao salvar o template"
 
-#: src/components/GeneralSettings.tsx:93
+#: src/components/GeneralSettings.tsx:92
 #: src/components/UpdatePasswordDialog.tsx:68
 #: src/components/UpdatePasswordDialog.tsx:73
 msgid "An unexpected error has occurred"
@@ -137,8 +141,8 @@ msgstr "Ocorreu um erro inesperado"
 
 #: src/components/ProfileSettings.tsx:73
 #: src/components/ProfileSettings.tsx:78
-#: src/components/forms/RegisterForm.tsx:90
-#: src/components/forms/RegisterForm.tsx:95
+#: src/components/forms/RegisterForm.tsx:93
+#: src/components/forms/RegisterForm.tsx:98
 msgid "An unknown error has occurred"
 msgstr "Ocorreu um erro desconhecido"
 
@@ -166,13 +170,17 @@ msgstr "Você tem certeza que deseja apagar esse modelo? {0, plural, one {Existe
 msgid "Are you sure you want to delete this note? {0, plural, one {It contains one flashcard} other {It contains # flashcards}}"
 msgstr "Você tem certeza que deseja apagar essa nota? {0, plural, one {Ela contém um flashcard} other {Ela contém # flashcards}}"
 
-#: src/components/FlashCardRenderer.tsx:68
+#: src/components/FlashCardRenderer.tsx:70
 msgid "Back side"
 msgstr "Verso"
 
-#: src/components/FlashCardRenderer.tsx:68
+#: src/components/FlashCardRenderer.tsx:70
 msgid "Back side template is empty"
 msgstr "Verso do template está vazio"
+
+#: src/components/pages/AddModelPage.tsx:189
+msgid "Base information"
+msgstr "Informações básicas"
 
 #: src/components/editor/BlockStyleControls.tsx:21
 msgid "Blockquote"
@@ -201,7 +209,7 @@ msgstr "Mudar senha"
 msgid "Change your account username"
 msgstr "Mude o nome de usuário de sua conta"
 
-#: src/components/pages/ForgotPasswordPage.tsx:91
+#: src/components/pages/ForgotPasswordPage.tsx:90
 msgid "Check your inbox!"
 msgstr "Verifique sua caixa de entrada!"
 
@@ -251,17 +259,21 @@ msgstr "Continuar estudando"
 msgid "Create"
 msgstr "Criar"
 
-#: src/components/pages/AddNotePage.tsx:190
+#: src/components/pages/AddNotePage.tsx:195
 msgid "Create a model"
 msgstr "Criar um modelo"
+
+#: src/components/ModelNameForm.tsx:19
+msgid "Create a name for your model."
+msgstr "Crie um nome para seu modelo."
 
 #: src/components/pages/DecksSection.tsx:44
 #: src/components/pages/DecksSection.tsx:60
 msgid "Create deck"
 msgstr "Criar deck"
 
-#: src/components/pages/AddModelPage.tsx:52
-#: src/components/pages/AddModelPage.tsx:184
+#: src/components/ModelTemplatesForm.tsx:82
+#: src/components/pages/AddModelPage.tsx:183
 #: src/components/pages/ModelsSection.tsx:43
 #: src/components/pages/ModelsSection.tsx:57
 msgid "Create model"
@@ -271,7 +283,7 @@ msgstr "Criar modelo"
 msgid "Create new deck"
 msgstr "Criar novo deck"
 
-#: src/components/pages/AddNotePage.tsx:131
+#: src/components/pages/AddNotePage.tsx:132
 msgid "Create note for deck <0>{0}</0>"
 msgstr "Criar nota para o deck <0>{0}</0>"
 
@@ -283,7 +295,7 @@ msgstr "Criar template"
 msgid "Create your account today and start studying for free!"
 msgstr "Crie sua conta hoje e comece a estudar de graça!"
 
-#: src/components/pages/AddModelPage.tsx:184
+#: src/components/ModelTemplatesForm.tsx:82
 msgid "Creating model..."
 msgstr "Criando modelo..."
 
@@ -295,13 +307,13 @@ msgstr "Senha atual"
 msgid "Current password is required to change your password"
 msgstr "Senha atual é obrigatória para mudar sua senha"
 
-#: src/components/Shell.tsx:51
+#: src/components/Shell.tsx:52
 msgid "Dark mode"
 msgstr "Modo escuro"
 
-#: src/components/pages/StatisticsPage.tsx:154
-#: src/components/pages/StatisticsPage.tsx:170
-#: src/components/pages/StatisticsPage.tsx:220
+#: src/components/pages/StatisticsPage.tsx:156
+#: src/components/pages/StatisticsPage.tsx:172
+#: src/components/pages/StatisticsPage.tsx:222
 msgid "Deck Statistics"
 msgstr "Estatísticas do deck"
 
@@ -321,7 +333,7 @@ msgstr "Detalhes do deck"
 msgid "Deck not found"
 msgstr "Deck não encontrado"
 
-#: src/components/pages/NotePage.tsx:166
+#: src/components/pages/NotePage.tsx:169
 msgid "Deck {0}"
 msgstr "Deck {0}"
 
@@ -334,7 +346,7 @@ msgstr "Decks"
 #: src/components/DeleteModelButton.tsx:71
 #: src/components/DeleteModelButton.tsx:91
 #: src/components/DeleteNoteDialog.tsx:53
-#: src/components/NotesTable.tsx:77
+#: src/components/NotesTable.tsx:79
 msgid "Delete"
 msgstr "Apagar"
 
@@ -378,40 +390,40 @@ msgstr "Não possui uma conta? <0>Cadastre-se</0>"
 msgid "Easy"
 msgstr "Fácil"
 
-#: src/components/NotesTable.tsx:74
+#: src/components/NotesTable.tsx:76
 msgid "Edit"
 msgstr "Editar"
 
-#: src/components/pages/ModelPage.tsx:151
-#: src/components/pages/ModelPage.tsx:163
+#: src/components/pages/ModelPage.tsx:153
+#: src/components/pages/ModelPage.tsx:165
 msgid "Edit fields"
 msgstr "Editar campos"
 
-#: src/components/pages/ModelPage.tsx:148
-#: src/components/pages/ModelPage.tsx:159
+#: src/components/pages/ModelPage.tsx:150
+#: src/components/pages/ModelPage.tsx:161
 msgid "Edit templates"
 msgstr "Editar templates"
 
 #: src/components/ProfileSettings.tsx:95
-#: src/components/forms/RegisterForm.tsx:114
+#: src/components/forms/RegisterForm.tsx:117
 msgid "Email"
 msgstr "Email"
 
-#: src/components/pages/ForgotPasswordPage.tsx:121
+#: src/components/pages/ForgotPasswordPage.tsx:120
 msgid "Email address"
 msgstr "Endereço de email"
 
 #: src/components/ProfileSettings.tsx:64
-#: src/components/forms/RegisterForm.tsx:46
+#: src/components/forms/RegisterForm.tsx:48
 msgid "Email is required"
 msgstr "Email é obrigatório"
 
 #: src/components/ProfileSettings.tsx:63
-#: src/components/forms/RegisterForm.tsx:72
+#: src/components/forms/RegisterForm.tsx:75
 msgid "Email must be a valid email"
 msgstr "Email precisa ser um email válido"
 
-#: src/components/pages/ForgotPasswordPage.tsx:58
+#: src/components/pages/ForgotPasswordPage.tsx:59
 msgid "Email sent!"
 msgstr "Email enviado!"
 
@@ -427,34 +439,35 @@ msgstr "Encerrar sessão de estudos"
 msgid "English"
 msgstr "Inglês"
 
-#: src/components/pages/ForgotPasswordPage.tsx:114
+#: src/components/pages/ForgotPasswordPage.tsx:113
 msgid "Enter the email associated with your account and we will send a link to reset your password"
 msgstr "Insira o email associado com a sua conta que iremos enviar um link para resetar sua senha"
 
-#: src/components/pages/ForgotPasswordPage.tsx:128
+#: src/components/pages/ForgotPasswordPage.tsx:127
 msgid "Enter your email address"
 msgstr "Insira o seu endereço de email"
 
-#: src/components/pages/AddModelPage.tsx:156
-msgid "Field #{index}"
-msgstr "Campo #{index}"
+#: src/components/views/Alert.tsx:30
+msgid "Error"
+msgstr "Erro"
 
 #: src/components/EditFieldsDialog.tsx:152
-#: src/components/pages/AddModelPage.tsx:161
+#: src/components/ModelFieldsForm.tsx:57
 msgid "Field name"
 msgstr "Nome do campo"
 
-#: src/components/pages/AddModelPage.tsx:76
+#: src/components/ModelFieldsForm.tsx:18
 msgid "Field name is required"
 msgstr "Nome do campo é obrigatório"
 
-#: src/components/FieldValueEditor.tsx:18
+#: src/components/FieldValueEditor.tsx:19
 msgid "Field value..."
 msgstr "Valor do campo..."
 
 #: src/components/EditFieldsDialog.tsx:138
-#: src/components/pages/AddModelPage.tsx:151
-#: src/components/pages/AddNotePage.tsx:152
+#: src/components/ModelFieldsForm.tsx:32
+#: src/components/pages/AddModelPage.tsx:192
+#: src/components/pages/AddNotePage.tsx:155
 msgid "Fields"
 msgstr "Campos"
 
@@ -466,12 +479,12 @@ msgstr "Campos que você pode utilizar em seus templates e notas. Você pode adi
 msgid "First page"
 msgstr "Primeira página"
 
-#: src/components/NotesTable.tsx:45
-#: src/components/pages/NotePage.tsx:183
+#: src/components/NotesTable.tsx:47
+#: src/components/pages/NotePage.tsx:186
 msgid "Flashcards"
 msgstr "Flashcards"
 
-#: src/components/pages/StatisticsPage.tsx:294
+#: src/components/pages/StatisticsPage.tsx:300
 msgid "Flashcards studied"
 msgstr "Flashcards estudados"
 
@@ -479,11 +492,11 @@ msgstr "Flashcards estudados"
 msgid "For security, please enter your current password to continue."
 msgstr "Por segurança, por favor digite sua senha atual para continuar."
 
-#: src/components/pages/ForgotPasswordPage.tsx:141
+#: src/components/pages/ForgotPasswordPage.tsx:140
 msgid "Forgot password"
 msgstr "Esqueceu a senha"
 
-#: src/components/pages/ForgotPasswordPage.tsx:110
+#: src/components/pages/ForgotPasswordPage.tsx:109
 msgid "Forgot password?"
 msgstr "Esqueceu a senha?"
 
@@ -491,11 +504,11 @@ msgstr "Esqueceu a senha?"
 msgid "Forgot your password?"
 msgstr "Esqueceu sua senha?"
 
-#: src/components/FlashCardRenderer.tsx:65
+#: src/components/FlashCardRenderer.tsx:67
 msgid "Front side"
 msgstr "Frente"
 
-#: src/components/FlashCardRenderer.tsx:65
+#: src/components/FlashCardRenderer.tsx:67
 msgid "Front side template is empty"
 msgstr "Frente do template está vazio"
 
@@ -508,14 +521,22 @@ msgstr "Voltar"
 msgid "Go to Home"
 msgstr "Voltar para a Página Inicial"
 
+#: src/components/ModelNameForm.tsx:25
+msgid "Go to fields"
+msgstr "Ir para campos"
+
 #: src/components/pages/DeckPage.tsx:143
 #: src/components/pages/ModelPage.tsx:100
 msgid "Go to home"
 msgstr "Voltar para a página inicial"
 
-#: src/components/pages/ForgotPasswordPage.tsx:103
+#: src/components/pages/ForgotPasswordPage.tsx:102
 msgid "Go to login"
 msgstr "Voltar para login"
+
+#: src/components/ModelFieldsForm.tsx:70
+msgid "Go to templates"
+msgstr "Ir para templates"
 
 #: src/components/pages/StudyPage.tsx:217
 msgid "Good"
@@ -553,15 +574,15 @@ msgstr "Difícil"
 msgid "Home"
 msgstr "Página Inicial"
 
-#: src/components/forms/RegisterForm.tsx:118
+#: src/components/forms/RegisterForm.tsx:121
 msgid "I agree to the <0>Terms & Conditions</0>"
 msgstr "Eu concordo com os <0>Termos e Condições</0>"
 
-#: src/components/pages/StatisticsPage.tsx:271
+#: src/components/pages/StatisticsPage.tsx:277
 msgid "Interval"
 msgstr "Intervalo"
 
-#: src/components/pages/ForgotPasswordPage.tsx:130
+#: src/components/pages/ForgotPasswordPage.tsx:129
 msgid "Invalid email"
 msgstr "Email inválido"
 
@@ -582,11 +603,11 @@ msgstr "Itálico"
 msgid "Items per page"
 msgstr "Itens por página"
 
-#: src/components/GeneralSettings.tsx:107
+#: src/components/GeneralSettings.tsx:106
 msgid "Language"
 msgstr "Idioma"
 
-#: src/components/Pagination.tsx:66
+#: src/components/Pagination.tsx:68
 msgid "Last page"
 msgstr "Última página"
 
@@ -594,7 +615,7 @@ msgstr "Última página"
 msgid "Learning"
 msgstr "Aprendendo"
 
-#: src/components/Shell.tsx:56
+#: src/components/Shell.tsx:57
 msgid "Log out"
 msgstr "Sair"
 
@@ -616,7 +637,7 @@ msgstr "Garanta que seu conhecimento irá durar"
 msgid "Marketplace"
 msgstr "Marketplace"
 
-#: src/components/pages/AddModelPage.tsx:95
+#: src/components/pages/AddModelPage.tsx:125
 msgid "Model created successfully"
 msgstr "Modelo criado com sucesso"
 
@@ -628,7 +649,7 @@ msgstr "Modelo apagado com sucesso"
 msgid "Model details"
 msgstr "Detalhes do modelo"
 
-#: src/components/pages/AddModelPage.tsx:107
+#: src/components/ModelNameForm.tsx:22
 msgid "Model name"
 msgstr "Nome do modelo"
 
@@ -636,7 +657,7 @@ msgstr "Nome do modelo"
 msgid "Model not found"
 msgstr "Modelo não encontrado"
 
-#: src/components/NotesTable.tsx:42
+#: src/components/NotesTable.tsx:44
 msgid "Model type"
 msgstr "Tipo do modelo"
 
@@ -648,7 +669,7 @@ msgstr "Modelos"
 msgid "Monospace"
 msgstr "Monoespaçada"
 
-#: src/components/pages/AddModelPage.tsx:74
+#: src/components/ModelNameForm.tsx:13
 msgid "Name is required"
 msgstr "Nome é obrigatório"
 
@@ -678,47 +699,39 @@ msgstr "Nova senha precisa ter no mínimo 6 caracteres"
 msgid "New template name"
 msgstr "Nome do novo template"
 
-#: src/components/Pagination.tsx:63
+#: src/components/Pagination.tsx:65
 msgid "Next page"
 msgstr "Próxima página"
 
-#: src/components/pages/AddModelPage.tsx:171
-msgid "No fields added"
-msgstr "Nenhum campo adicionado"
-
-#: src/components/NotesTable.tsx:57
+#: src/components/NotesTable.tsx:59
 msgid "No notes were found"
 msgstr "Nenhuma nota foi encontrada"
 
-#: src/components/pages/AddModelPage.tsx:135
-msgid "No templates added"
-msgstr "Nenhum template adicionado"
-
-#: src/components/NotesTable.tsx:39
+#: src/components/NotesTable.tsx:41
 msgid "Note"
 msgstr "Nota"
 
-#: src/components/pages/AddNotePage.tsx:104
+#: src/components/pages/AddNotePage.tsx:105
 msgid "Note created successfully"
 msgstr "Nota criada com sucesso"
 
-#: src/components/pages/NotePage.tsx:169
+#: src/components/pages/NotePage.tsx:172
 msgid "Note details"
 msgstr "Detalhes da nota"
 
-#: src/components/pages/AddNotePage.tsx:139
+#: src/components/pages/AddNotePage.tsx:142
 msgid "Note's model"
 msgstr "Modelo da nota"
 
-#: src/components/pages/DeckPage.tsx:176
+#: src/components/pages/DeckPage.tsx:178
 msgid "Notes"
 msgstr "Notas"
 
-#: src/components/pages/StatisticsPage.tsx:261
+#: src/components/pages/StatisticsPage.tsx:267
 msgid "Number of flashcards studied"
 msgstr "Número de flashcards estudados"
 
-#: src/components/pages/StatisticsPage.tsx:260
+#: src/components/pages/StatisticsPage.tsx:266
 msgid "Number of times studied"
 msgstr "Número de vezes estudado"
 
@@ -730,13 +743,13 @@ msgstr "Lista numerada"
 msgid "Optimize your knowledge retention with this effective study method."
 msgstr "Otimize a sua retenção de conhecimento com esse método efetivo de estudo."
 
-#: src/components/pages/StatisticsPage.tsx:234
+#: src/components/pages/StatisticsPage.tsx:240
 msgid "Overview"
 msgstr "Visão geral"
 
 #: src/components/ProfileSettings.tsx:98
 #: src/components/forms/LoginForm.tsx:69
-#: src/components/forms/RegisterForm.tsx:115
+#: src/components/forms/RegisterForm.tsx:118
 msgid "Password"
 msgstr "Senha"
 
@@ -746,11 +759,11 @@ msgid "Password changed successfully"
 msgstr "Senha alterada com sucesso"
 
 #: src/components/forms/LoginForm.tsx:22
-#: src/components/forms/RegisterForm.tsx:47
+#: src/components/forms/RegisterForm.tsx:49
 msgid "Password is required"
 msgstr "Senha é obrigatória"
 
-#: src/components/forms/RegisterForm.tsx:76
+#: src/components/forms/RegisterForm.tsx:79
 #: src/components/pages/ResetPasswordPage.tsx:130
 msgid "Password must be at least 6 characters"
 msgstr "Senha precisa ter pelo menos 6 caracteres"
@@ -763,15 +776,15 @@ msgstr "Por favor, tente recarregar a página"
 msgid "Portuguese"
 msgstr "Português"
 
-#: src/components/GeneralSettings.tsx:105
+#: src/components/GeneralSettings.tsx:104
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/components/GeneralSettings.tsx:96
+#: src/components/GeneralSettings.tsx:95
 msgid "Preferences updated successfully"
 msgstr "Preferências atualizadas com sucesso"
 
-#: src/components/pages/NotePage.tsx:214
+#: src/components/pages/NotePage.tsx:218
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -800,17 +813,17 @@ msgstr "Pronto para funcionar offline"
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: src/components/forms/RegisterForm.tsx:49
-#: src/components/forms/RegisterForm.tsx:127
+#: src/components/forms/RegisterForm.tsx:51
+#: src/components/forms/RegisterForm.tsx:130
 #: src/components/pages/RegisterPage.tsx:12
 msgid "Register"
 msgstr "Cadastrar"
 
-#: src/components/pages/AddModelPage.tsx:164
+#: src/components/ModelFieldsForm.tsx:60
 msgid "Remove field"
 msgstr "Remover campo"
 
-#: src/components/pages/AddModelPage.tsx:128
+#: src/components/ModelTemplatesForm.tsx:72
 msgid "Remove template"
 msgstr "Remover template"
 
@@ -830,7 +843,7 @@ msgstr "Renomear template {0}"
 msgid "Repeat"
 msgstr "Repetir"
 
-#: src/components/pages/ForgotPasswordPage.tsx:135
+#: src/components/pages/ForgotPasswordPage.tsx:134
 msgid "Request Password Reset"
 msgstr "Solicitar Alteração de Senha"
 
@@ -855,7 +868,7 @@ msgstr "Tentar novamente"
 msgid "Review"
 msgstr "Revisão"
 
-#: src/components/GeneralSettings.tsx:148
+#: src/components/GeneralSettings.tsx:147
 msgid "Save preferences"
 msgstr "Salvar preferências"
 
@@ -867,19 +880,19 @@ msgstr "Salvar perfil"
 msgid "Saved successfully"
 msgstr "Salvo com sucesso"
 
-#: src/components/NotesTable.tsx:32
+#: src/components/NotesTable.tsx:34
 msgid "Search notes..."
 msgstr "Buscar notas..."
 
-#: src/components/pages/AddNotePage.tsx:142
+#: src/components/pages/AddNotePage.tsx:145
 msgid "Select a model"
 msgstr "Selecione um modelo"
 
-#: src/components/pages/StatisticsPage.tsx:224
+#: src/components/pages/StatisticsPage.tsx:228
 msgid "Select your deck"
 msgstr "Selecione seu deck"
 
-#: src/components/Shell.tsx:46
+#: src/components/Shell.tsx:47
 #: src/components/pages/SettingsPage.tsx:10
 msgid "Settings"
 msgstr "Configurações"
@@ -908,10 +921,14 @@ msgstr "Algo de errado aconteceu"
 msgid "Start Session"
 msgstr "Começar sessão"
 
-#: src/components/Shell.tsx:74
+#: src/components/Shell.tsx:79
 #: src/components/pages/HomePage.tsx:104
 msgid "Statistics"
 msgstr "Estatísticas"
+
+#: src/components/StepTab.tsx:26
+msgid "Step {0}"
+msgstr "Passo {0}"
 
 #: src/components/pages/HomePage.tsx:140
 msgid "Study"
@@ -921,7 +938,7 @@ msgstr "Estudar"
 msgid "Study deck"
 msgstr "Estudar deck"
 
-#: src/components/pages/StatisticsPage.tsx:267
+#: src/components/pages/StatisticsPage.tsx:273
 msgid "Study frequency"
 msgstr "Frequência do estudo"
 
@@ -929,9 +946,9 @@ msgstr "Frequência do estudo"
 msgid "Study today"
 msgstr "Estude hoje"
 
-#: src/components/pages/AddModelPage.tsx:120
-msgid "Template #{index}"
-msgstr "Template #{index}"
+#: src/components/views/Alert.tsx:27
+msgid "Success"
+msgstr "Sucesso"
 
 #: src/components/pages/ModelPage.tsx:79
 msgid "Template back side"
@@ -942,17 +959,18 @@ msgid "Template front side"
 msgstr "Frente do template"
 
 #: src/components/EditTemplatesDialog.tsx:173
-#: src/components/pages/AddModelPage.tsx:125
+#: src/components/ModelTemplatesForm.tsx:69
 msgid "Template name"
 msgstr "Nome do template"
 
-#: src/components/pages/AddModelPage.tsx:79
+#: src/components/ModelTemplatesForm.tsx:19
 msgid "Template name is required"
 msgstr "Nome do template é obrigatório"
 
 #: src/components/EditTemplatesDialog.tsx:162
-#: src/components/pages/AddModelPage.tsx:115
-#: src/components/pages/ModelPage.tsx:135
+#: src/components/ModelTemplatesForm.tsx:33
+#: src/components/pages/AddModelPage.tsx:195
+#: src/components/pages/ModelPage.tsx:137
 msgid "Templates"
 msgstr "Templates"
 
@@ -964,9 +982,13 @@ msgstr "Templates do modelo atual"
 msgid "Terms and Conditions"
 msgstr "Termos e Condições"
 
-#: src/components/pages/AddNotePage.tsx:168
+#: src/components/pages/AddNotePage.tsx:171
 msgid "The selected model doesn't have any fields. <0>Click here to edit it</0>"
 msgstr "O modelo selecionado não possui nenhum campo. <0>Clique aqui para editá-lo</0>"
+
+#: src/components/ModelTemplatesForm.tsx:42
+msgid "The templates are used to define the frontside and backside of each flashcard, using the fields defined in the previous step. You'll be able to edit the template's content after creating the model."
+msgstr "Os templates são usados para definir a frente e o verso de cada flashcard, usando os campos definidos no passo anterior. Você poderá editar o conteúdo do template após criar o modelo."
 
 #: src/components/forms/AddDeckForm.tsx:37
 msgid "The title is required"
@@ -984,7 +1006,7 @@ msgstr "Essa ação irá apagar todos os valores das notas associadas com esse c
 msgid "This link may be broken or the typed URL is incorrect."
 msgstr "Este link pode estar quebrado ou a URL digitada está incorreta."
 
-#: src/components/GeneralSettings.tsx:122
+#: src/components/GeneralSettings.tsx:121
 msgid "Time zone"
 msgstr "Fuso horário"
 
@@ -992,11 +1014,11 @@ msgstr "Fuso horário"
 msgid "Title"
 msgstr "Título"
 
-#: src/components/pages/AddNotePage.tsx:182
+#: src/components/pages/AddNotePage.tsx:187
 msgid "To create a note you need to associate it with a model."
 msgstr "Para criar uma nota você precisa associá-la a um modelo."
 
-#: src/components/pages/StatisticsPage.tsx:238
+#: src/components/pages/StatisticsPage.tsx:244
 msgid "Total study time"
 msgstr "Tempo total de estudo"
 
@@ -1005,11 +1027,11 @@ msgstr "Tempo total de estudo"
 msgid "Try again"
 msgstr "Tentar novamente"
 
-#: src/components/pages/StatisticsPage.tsx:177
+#: src/components/pages/StatisticsPage.tsx:179
 msgid "Try creating a deck first and study it in order to see your study statistics here."
 msgstr "Tente primeiro criar um deck e estude-o para que possa ver suas estatísticas de estudo aqui."
 
-#: src/components/pages/StatisticsPage.tsx:324
+#: src/components/pages/StatisticsPage.tsx:330
 msgid "Try selecting a broader interval above."
 msgstr "Tente selecionar um intervalo mais amplo acima."
 
@@ -1029,53 +1051,54 @@ msgstr "Atualizar senha da conta"
 msgid "Update your account email"
 msgstr "Atualize o email de sua conta"
 
-#: src/components/GeneralSettings.tsx:107
+#: src/components/GeneralSettings.tsx:106
 msgid "Update your preferred language for headlines, buttons and other texts."
 msgstr "Atualize sua língua preferida para manchetes, botões e outros textos."
 
-#: src/components/GeneralSettings.tsx:122
+#: src/components/GeneralSettings.tsx:121
 msgid "Used to compute the statistics and study schedule in your local time."
 msgstr "Usado para computar as estatísticas e o cronograma de estudo em seu tempo local."
 
-#: src/components/pages/ForgotPasswordPage.tsx:62
+#: src/components/pages/ForgotPasswordPage.tsx:63
 msgid "User not found"
 msgstr "Usuário não encontrado"
 
 #: src/components/ProfileSettings.tsx:92
 #: src/components/forms/LoginForm.tsx:68
-#: src/components/forms/RegisterForm.tsx:113
+#: src/components/forms/RegisterForm.tsx:116
 msgid "Username"
 msgstr "Nome de usuário"
 
 #: src/components/ProfileSettings.tsx:60
 #: src/components/forms/LoginForm.tsx:21
-#: src/components/forms/RegisterForm.tsx:45
+#: src/components/forms/RegisterForm.tsx:47
 msgid "Username is required"
 msgstr "Nome de usuário é obrigatório"
 
 #: src/components/ProfileSettings.tsx:57
-#: src/components/forms/RegisterForm.tsx:66
+#: src/components/forms/RegisterForm.tsx:69
 msgid "Username must be at least 4 characters"
 msgstr "Nome de usuário precisa ter pelo menos 4 caracteres"
 
 #: src/components/ProfileSettings.tsx:58
-#: src/components/forms/RegisterForm.tsx:67
+#: src/components/forms/RegisterForm.tsx:70
 msgid "Username must be at most 20 characters"
 msgstr "Nome de usuário precisa ter no máximo 20 caracteres"
 
 #: src/components/ProfileSettings.tsx:59
-#: src/components/forms/RegisterForm.tsx:68
+#: src/components/forms/RegisterForm.tsx:71
 msgid "Username must consist only of alphanumeric characters and underscores"
 msgstr "O nome de usuário precisa conter apenas caracteres alfanuméricos e sublinhas"
 
 #: src/components/forms/AddDeckForm.tsx:76
-#: src/components/pages/AddModelPage.tsx:97
-#: src/components/pages/AddNotePage.tsx:106
+#: src/components/pages/AddModelPage.tsx:127
+#: src/components/pages/AddNotePage.tsx:107
 msgid "View"
 msgstr "Ver"
 
 #: src/components/EditFieldsDialog.tsx:164
 #: src/components/EditTemplatesDialog.tsx:184
+#: src/components/views/Alert.tsx:30
 msgid "Warning"
 msgstr "Atenção"
 
@@ -1083,23 +1106,23 @@ msgstr "Atenção"
 msgid "We couldn't find the page you requested"
 msgstr "Não conseguimos encontrar a página requisitada"
 
-#: src/components/pages/StatisticsPage.tsx:174
+#: src/components/pages/StatisticsPage.tsx:176
 msgid "We don't have anything to show to you right now."
 msgstr "Nós ainda não temos nada para lhe mostrar agora."
 
-#: src/components/pages/StatisticsPage.tsx:319
+#: src/components/pages/StatisticsPage.tsx:325
 msgid "We don't have enough data to display in the supplied period."
 msgstr "Não temos dados suficientes para mostrar no período fornecido."
 
-#: src/components/pages/ForgotPasswordPage.tsx:96
+#: src/components/pages/ForgotPasswordPage.tsx:95
 msgid "We have sent you an email with instructions to help you reset your password. Remember to also check the spam folder."
 msgstr "Mandamos um email para você com instruções que vão te ajudar a resetar sua senha. Lembre-se de também checar a pasta de spam."
 
-#: src/components/pages/AddModelPage.tsx:66
+#: src/components/ModelTemplatesForm.tsx:51
 msgid "When you create a note, we will create the corresponding number of flashcards based on how much templates the note's model has, and will use the note's values to fill in the template."
 msgstr "Quando você criar uma nota, nós iremos criar o número correspondente de flashcards baseado em quantos templates o modelo possui, e iremos utilizar os valores da nota para preencher o template."
 
-#: src/components/pages/AddNotePage.tsx:178
+#: src/components/pages/AddNotePage.tsx:183
 msgid "You haven't created a model yet."
 msgstr "Você ainda não criou um modelo."
 
@@ -1111,11 +1134,11 @@ msgstr "Você ainda não criou nenhum deck."
 msgid "You haven't created any models yet"
 msgstr "Você ainda não criou nenhum modelo."
 
-#: src/components/NotesTable.tsx:53
+#: src/components/NotesTable.tsx:55
 msgid "You haven't created any notes on this deck yet"
 msgstr "Você ainda não criou nenhuma nota neste deck"
 
-#: src/components/pages/ModelPage.tsx:181
+#: src/components/pages/ModelPage.tsx:183
 msgid "You haven't created any templates on this model yet."
 msgstr "Você ainda não criou nenhum template neste modelo."
 
@@ -1135,12 +1158,12 @@ msgstr "Seu modelo não está salvo, você tem certeza que quer sair da página?
 msgid "Your models"
 msgstr "Seus modelos"
 
-#: src/components/pages/NotePage.tsx:133
+#: src/components/pages/NotePage.tsx:136
 msgid "Your note is not saved, are you sure you want to exit the page?"
 msgstr "Sua nota não está salva, tem certeza que quer sair da página?"
 
-#: src/components/NotesTable.tsx:63
-#: src/components/pages/NotePage.tsx:173
+#: src/components/NotesTable.tsx:65
+#: src/components/pages/NotePage.tsx:176
 msgid "empty note"
 msgstr "nota vazia"
 
@@ -1157,14 +1180,14 @@ msgid "{0, plural, one {# field} other {# fields}}"
 msgstr "{0, plural, one {# campo} other {# campos}}"
 
 #: src/components/DeckCard.tsx:64
-#: src/components/pages/DeckPage.tsx:168
-#: src/components/pages/ModelPage.tsx:125
+#: src/components/pages/DeckPage.tsx:170
+#: src/components/pages/ModelPage.tsx:127
 msgid "{0, plural, one {# flashcard} other {# flashcards}}"
 msgstr "{0, plural, one {# flashcard} other {# flashcards}}"
 
 #: src/components/DeckCard.tsx:59
-#: src/components/pages/DeckPage.tsx:166
-#: src/components/pages/ModelPage.tsx:120
+#: src/components/pages/DeckPage.tsx:168
+#: src/components/pages/ModelPage.tsx:122
 msgid "{0, plural, one {# note} other {# notes}}"
 msgstr "{0, plural, one {# nota} other {# notas}}"
 
@@ -1180,7 +1203,7 @@ msgstr "{0, plural, zero {# decks} one {# deck} other {# decks}}"
 msgid "{0, plural, zero {# models} one {# model} other {# models}}"
 msgstr "{0, plural, zero {# modelos} one {# modelo} other {# modelos}}"
 
-#: src/components/pages/StatisticsPage.tsx:238
+#: src/components/pages/StatisticsPage.tsx:244
 msgid "{0, select, millisecond {{1, plural, one {{formattedStudyTime} millisecond} other {{formattedStudyTime} milliseconds}}} second {{2, plural, one {{formattedStudyTime} second} other {{formattedStudyTime} seconds}}} minute {{3, plural, one {{formattedStudyTime} minute} other {{formattedStudyTime} minutes}}} hour {{4, plural, one {{formattedStudyTime} hour} other {{formattedStudyTime} hours}}} day {{5, plural, one {{formattedStudyTime} day} other {{formattedStudyTime} days}}}}"
 msgstr "{0, select, millisecond {{1, plural, one {{formattedStudyTime} millisegundo} other {{formattedStudyTime} millisegundos}}} second {{2, plural, one {{formattedStudyTime} segundo} other {{formattedStudyTime} segundos}}} minute {{3, plural, one {{formattedStudyTime} minuto} other {{formattedStudyTime} minutos}}} hour {{4, plural, one {{formattedStudyTime} hora} other {{formattedStudyTime} horas}}} day {{5, plural, one {{formattedStudyTime} dia} other {{formattedStudyTime} dias}}}}"
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,15 +102,10 @@ module.exports = {
     },
   },
   variants: {
-    display: ['responsive', 'group-hover', 'group-focus'],
-    opacity: [
-      'responsive',
-      'hover',
-      'focus',
-      'active',
-      'group-hover',
-      'group-focus',
-    ],
+    extend: {
+      display: ['group-hover', 'group-focus'],
+      opacity: ['group-focus'],
+    },
   },
   purge: {
     content: ['./src/**/*.tsx'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2255,6 +2255,16 @@
     prop-types "^15.7.2"
     tslib "^2.0.0"
 
+"@reach/alert@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.13.0.tgz#1f67b389f49af61286ef03a84f5a57bd3503dadf"
+  integrity sha512-5lpgRnlQ0JHBsRTPfKjD9aFPDZuLcaxTgD5PXdSLb+1CU8WgNbcy+7qSjqnu1uzWS2pQenIEBViV5wGpt63ADw==
+  dependencies:
+    "@reach/utils" "0.13.0"
+    "@reach/visually-hidden" "0.13.0"
+    prop-types "^15.7.2"
+    tslib "^2.0.0"
+
 "@reach/auto-id@0.11.2":
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.11.2.tgz#c66a905c5401d1ac3da8d26165b8d27d6e778fa6"
@@ -2403,10 +2413,26 @@
     tslib "^2.0.0"
     warning "^4.0.3"
 
+"@reach/utils@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.13.0.tgz#2da775a910d8894bb34e1e94fe95842674f71844"
+  integrity sha512-dypxuyA1Qy3LHxzzyS7jFGPgCCR04b8UEn+Tv/aj6y9V578dULQqkcCyobrdEa+OI8lxH7dFFHa+jH8M/noBrQ==
+  dependencies:
+    "@types/warning" "^3.0.0"
+    tslib "^2.0.0"
+    warning "^4.0.3"
+
 "@reach/visually-hidden@0.11.1", "@reach/visually-hidden@^0.11.1":
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.11.1.tgz#3d7a5742acf18372f35b9e216680edd8073f35e3"
   integrity sha512-TZZNSttor2jG6ZPGI35s/8G0FNSz49QrJIhAZbnUqHyPf3+jtNqAC0dOWW8Nuk+mApDDDVYd2KZ9P2vnzllNnQ==
+  dependencies:
+    tslib "^2.0.0"
+
+"@reach/visually-hidden@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.13.0.tgz#cace36d9bb80ffb797374fcaea989391b881038f"
+  integrity sha512-LF11WL9/495Q3d86xNy0VO6ylPI6SqF2xZGg9jpZSXLbFKpQ5Bf0qC7DOJfSf+/yb9WgPgB4m+a48Fz8AO6oZA==
   dependencies:
     tslib "^2.0.0"
 
@@ -4258,6 +4284,14 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.4.0.tgz#6fd082336fde4d026e9e448576189ee5265fa51a"
   integrity sha512-uTHDeu2xI5E1IFwf37JFQM31RrH7mY7877RqPBS4ZqSNUwoLDuct8AhBWaXGnVizBAYyimVwgCyGa9z/NiRhXA==
+
+"@xstate/react@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.2.2.tgz#54d32034d40384782ee11145bbbb31b841a5a464"
+  integrity sha512-pXcUtts6EaEUmquzpMZ2yhAZZLAFYxKVaaHnQ8MPWpGuby0B5QMch17Ij59+LGQACQTSE0nDqXrvvBQId6m8qQ==
+  dependencies:
+    use-isomorphic-layout-effect "^1.0.0"
+    use-subscription "^1.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -17859,6 +17893,13 @@ use-sidecar@^1.0.1:
     detect-node-es "^1.0.0"
     tslib "^1.9.3"
 
+use-subscription@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
+  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
+  dependencies:
+    object-assign "^4.1.1"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -18590,6 +18631,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xstate@^4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.16.0.tgz#e434d0558c0f9a7e9212802834992a6c2f47bca6"
+  integrity sha512-2k/49QYLdzG6Ye1JQWYFuPdU6dnRqHXcuFLxuORiuel04GjApSPct7wp2SOz9RAlNME5EkzclRKw1fHm5yejuA==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR simplifies the UI for create model page by converting it into a steps-based UI, as you can see below. I also updated it to use `xstate` as it simplified a lot of logic that lived inside the component itself to a more succinct schema that the library uses.

![image](https://user-images.githubusercontent.com/10223856/107859670-be3f7680-6e19-11eb-9c58-7e5893edb099.png)